### PR TITLE
Add Change Log URL to project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ def load_readme_file():
 AUTHOR = "Jack De Winter"
 AUTHOR_EMAIL = "jack.de.winter@outlook.com"
 PROJECT_URL = "https://github.com/jackdewinter/pymarkdown"
+PROJECT_URLS = {
+    "Change Log": "https://github.com/jackdewinter/pymarkdown/blob/main/changelog.md",
+}
 
 PACKAGE_NAME = "pymarkdownlnt"
 SEMANTIC_VERSION = get_semantic_version()
@@ -67,6 +70,7 @@ setup(
     long_description_content_type=LONG_DESCRIPTION_CONTENT_TYPE,
     keywords=KEYWORDS,
     classifiers=PROJECT_CLASSIFIERS,
+    project_urls=PROJECT_URLS,
     entry_points={
         "console_scripts": [
             "pymarkdown=pymarkdown.__main__:main",


### PR DESCRIPTION
For easy/"standard" access from the PyPI project page.

`Change Log` matches the title of the linked doc here, and is one of the
recognized names that get the distinctive icon:
https://github.com/pypa/warehouse/blob/64102a6a41f024e54bc0cfe52201d44bc80afd17/warehouse/templates/packaging/detail.html#L24

An example how it looks can be found e.g. in
https://pypi.org/project/black/