### PR TITLE
Move dial home marker file to user cache dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,10 @@ WARN: Current application version '0.9.2' differs from the published version '0.
 This dial home feature can be forced to run by using the `--force-version` command
 line flag and it can also be disabled by using the `--disable-version` command
 line flag.  To keep track of the last time that the dial home check was successfully
-performed, a `.pymarkdownlnt` file is created in the user's home directory containing
-the timestamp of the last successful check.
+performed, a `pymarkdownlnt` dir and `dial_home_marker` file in it is created in
+the user's
+[cache directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+containing the timestamp of the last successful check.
 
 ## Open Issues and Future Plans
 

--- a/pymarkdown/dial_home_helper.py
+++ b/pymarkdown/dial_home_helper.py
@@ -98,7 +98,10 @@ class DialHomeHelper:
         """
         Get the path to the marker file.
         """
-        return os.path.join(Path.home(), f".{self.__package_name}")
+        return os.path.join(
+            os.getenv("XDG_CACHE_HOME", Path.home() / ".cache"),
+            self.__package_name, "dial_home_marker"
+        )
 
     # pylint: disable=broad-except
     def __get_marker_epochs(self):
@@ -137,6 +140,7 @@ class DialHomeHelper:
         error_value = None
         marker_line = f"{current_timestamp}\n"
         try:
+            os.makedirs(os.path.dirname(self.marker_path), exist_ok=True)
             with open(self.marker_path, "wt") as marker_file:
                 marker_file.write(marker_line)
         except Exception as this_exception:


### PR DESCRIPTION
I'm disappointed to see the dial home feature, especially as it's enabled by default. But if the feature is here to stay in the first place (no matter if enabled by default or not), let's at least not clutter the user home dir with dotfiles: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html