### PR TITLE
Fix reading requirements file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 def parse_requirements():
     with open("install-requirements.txt", "r", encoding="utf-8") as requirement_file:
-        lineiter = (line.strip() for line in requirement_file)
+        lineiter = [line.strip() for line in requirement_file]
     return [line for line in lineiter if line and not line.startswith("#")]
 
 


### PR DESCRIPTION
Actually read the file while it's open instead of returning a generator that does it too late:

```
$ python setup.py build
Traceback (most recent call last):
  File ".../pymarkdown/setup.py", line 63, in <module>
    install_requires=parse_requirements(),
  File ".../pymarkdown/setup.py", line 13, in parse_requirements
    return [line for line in lineiter if line and not line.startswith("#")]
  File ".../pymarkdown/setup.py", line 13, in <listcomp>
    return [line for line in lineiter if line and not line.startswith("#")]
  File ".../pymarkdown/setup.py", line 12, in <genexpr>
    lineiter = (line.strip() for line in requirement_file)
ValueError: I/O operation on closed file.
```