### PR TITLE
Issue 626

### DIFF
--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -2,12 +2,12 @@
     "projectName": "pymarkdown",
     "reportSource": "pytest",
     "branchLevel": {
-        "totalMeasured": 3585,
-        "totalCovered": 3585
+        "totalMeasured": 3589,
+        "totalCovered": 3589
     },
     "lineLevel": {
-        "totalMeasured": 14649,
-        "totalCovered": 14649
+        "totalMeasured": 14675,
+        "totalCovered": 14675
     }
 }
 

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1452,7 +1452,7 @@
         },
         {
             "name": "test.test_main",
-            "totalTests": 51,
+            "totalTests": 52,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -404,7 +404,7 @@
         },
         {
             "name": "test.gfm.test_markdown_fenced_code_blocks",
-            "totalTests": 68,
+            "totalTests": 77,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -420,7 +420,7 @@
         },
         {
             "name": "test.gfm.test_markdown_html_blocks",
-            "totalTests": 76,
+            "totalTests": 85,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1284,7 +1284,7 @@
         },
         {
             "name": "test.rules.test_md031",
-            "totalTests": 22,
+            "totalTests": 23,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,

--- a/pymarkdown/block_quotes/block_quote_processor.py
+++ b/pymarkdown/block_quotes/block_quote_processor.py
@@ -10,7 +10,10 @@ from pymarkdown.block_quotes.block_quote_non_fenced_helper import (
     BlockQuoteNonFencedHelper,
 )
 from pymarkdown.container_blocks.container_grab_bag import ContainerGrabBag
-from pymarkdown.container_markdown_token import BlockQuoteMarkdownToken
+from pymarkdown.container_markdown_token import (
+    BlockQuoteMarkdownToken,
+    ListStartMarkdownToken,
+)
 from pymarkdown.leaf_blocks.leaf_block_processor import LeafBlockProcessor
 from pymarkdown.markdown_token import MarkdownToken
 from pymarkdown.parser_logger import ParserLogger
@@ -370,6 +373,22 @@ class BlockQuoteProcessor:
             extracted_whitespace,
             adj_ws=adj_ws,
         )
+        if (
+            really_start
+            and parser_state.token_stack[-1].is_fenced_code_block
+            and parser_state.token_stack[-2].is_list
+        ):
+            start_index = position_marker.index_number
+            POGGER.debug("start_index>>$", start_index)
+            list_token = cast(
+                ListStartMarkdownToken,
+                parser_state.token_stack[-2].matching_markdown_token,
+            )
+            POGGER.debug("list_token>>$", list_token)
+            POGGER.debug("list_token.indent_level>>$", list_token.indent_level)
+            really_start = start_index < list_token.indent_level
+            POGGER.debug("really_start>>$", really_start)
+
         if really_start:
             POGGER.debug(
                 "handle_block_quote_block>>token_stack[depth]>:$:<",

--- a/pymarkdown/container_blocks/container_block_leaf_processor.py
+++ b/pymarkdown/container_blocks/container_block_leaf_processor.py
@@ -68,18 +68,18 @@ class ContainerBlockLeafProcessor:
             and parser_state.token_stack[-2].is_block_quote
         )
 
-        # POGGER.debug("ttp>>:$:<", position_marker.text_to_parse)
-        # POGGER.debug("index_number>>:$:<", position_marker.index_number)
-        # POGGER.debug("index_indent>>:$:<", position_marker.index_indent)
+        POGGER.debug("ttp>>:$:<", position_marker.text_to_parse)
+        POGGER.debug("index_number>>:$:<", position_marker.index_number)
+        POGGER.debug("index_indent>>:$:<", position_marker.index_indent)
         newer_position_marker = PositionMarker(
             position_marker.line_number,
             grab_bag.start_index,
             grab_bag.line_to_parse,
             index_indent=calculated_indent,
         )
-        # POGGER.debug("ttp>>:$:<", newer_position_marker.text_to_parse)
-        # POGGER.debug("index_number>>:$:<", newer_position_marker.index_number)
-        # POGGER.debug("index_indent>>:$:<", newer_position_marker.index_indent)
+        POGGER.debug("ttp>>:$:<", newer_position_marker.text_to_parse)
+        POGGER.debug("index_number>>:$:<", newer_position_marker.index_number)
+        POGGER.debug("index_indent>>:$:<", newer_position_marker.index_indent)
         parser_state.mark_for_leaf_processing(grab_bag.container_tokens)
 
         ContainerBlockLeafProcessor.__process_leaf_tokens(
@@ -108,6 +108,8 @@ class ContainerBlockLeafProcessor:
             xposition_marker.text_to_parse,
             index_indent=xposition_marker.index_indent,
         )
+        # POGGER.debug("position_marker.text>>:$:<<", position_marker.text_to_parse)
+        # POGGER.debug("position_marker.index>>:$:<<", position_marker.index_number)
 
         (
             new_index_number,
@@ -140,6 +142,8 @@ class ContainerBlockLeafProcessor:
             position_marker.line_number,
         )
 
+        # POGGER.debug("position_marker.text>>:$:<<", position_marker.text_to_parse)
+        # POGGER.debug("position_marker.index>>:$:<<", position_marker.index_number)
         (
             removed_leading_space,
             actual_removed_leading_space,
@@ -153,6 +157,8 @@ class ContainerBlockLeafProcessor:
             grab_bag,
         )
 
+        # POGGER.debug("position_marker.text>>:$:<<", position_marker.text_to_parse)
+        # POGGER.debug("position_marker.index>>:$:<<", position_marker.index_number)
         if (
             grab_bag.is_leaf_tokens_empty()
             and not grab_bag.do_skip_containers_before_leaf_blocks
@@ -168,6 +174,8 @@ class ContainerBlockLeafProcessor:
                     grab_bag,
                 )
             )
+            # POGGER.debug("position_marker.text>>:$:<<", position_marker.text_to_parse)
+            # POGGER.debug("position_marker.index>>:$:<<", position_marker.index_number)
 
         ContainerBlockLeafProcessor.__parse_line_for_leaf_blocks(
             parser_state,

--- a/pymarkdown/list_blocks/list_block_processor.py
+++ b/pymarkdown/list_blocks/list_block_processor.py
@@ -527,14 +527,12 @@ class ListBlockProcessor:
             extracted_whitespace,
             leading_space_length,
         )
-
         POGGER.debug(
             "leading_space_length>>$>>requested_list_indent>>$>>is_in_paragraph>>$",
             leading_space_length,
             requested_list_indent,
             parser_state.token_stack[-1].is_paragraph,
         )
-
         used_indent = None
         was_paragraph_continuation = (
             leading_space_length >= requested_list_indent and allow_list_continue
@@ -766,6 +764,7 @@ class ListBlockProcessor:
                 original_line,
             )
 
+        # POGGER.debug(">>line_to_parse>>$>>",line_to_parse)
         return (
             container_level_tokens,
             line_to_parse,
@@ -927,6 +926,8 @@ class ListBlockProcessor:
                         original_line, remaining_indent, removed_whitespace
                     )
                 )
+        POGGER.debug("padded_spaces($)", padded_spaces)
+        POGGER.debug("line_to_parse[start_index:]($)", line_to_parse[start_index:])
         POGGER.debug("removed_whitespace($)", removed_whitespace)
         return (
             f"{padded_spaces}{line_to_parse[start_index:]}",

--- a/pymarkdown/plugin_manager/plugin_manager.py
+++ b/pymarkdown/plugin_manager/plugin_manager.py
@@ -743,12 +743,12 @@ class PluginManager:
             for next_rule_identifier in enable_rules_from_command_line.lower().split(
                 ","
             ):
-                command_line_enabled_rules.add(next_rule_identifier)
+                command_line_enabled_rules.add(next_rule_identifier.strip())
         if disable_rules_from_command_line:
             for next_rule_identifier in disable_rules_from_command_line.lower().split(
                 ","
             ):
-                command_line_disabled_rules.add(next_rule_identifier)
+                command_line_disabled_rules.add(next_rule_identifier.strip())
 
         for plugin_instance, instance_file_name in self.__loaded_classes:
             self.__register_individual_plugin(

--- a/test/gfm/test_markdown_fenced_code_blocks.py
+++ b/test/gfm/test_markdown_fenced_code_blocks.py
@@ -1960,3 +1960,324 @@ def
 
     # Act & Assert
     act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09x():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   ```yaml
+   def:
+      - ghi
+   ```"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,4):`:3:yaml:::::]",
+        "[text(3,4):def:\n   - ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<pre><code class="language-yaml">def:
+   - ghi
+</code></pre>
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09a():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  ```yaml
+  def:
+     - ghi
+  ```"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,3):`:3:yaml:::::]",
+        "[text(3,3):def:\n   - ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<pre><code class="language-yaml">def:
+   - ghi
+</code></pre>
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09b():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """> abc
+> ```yaml
+> def:
+>    - ghi
+> ```"""
+    expected_tokens = [
+        "[block-quote(1,1)::> \n> \n> \n> \n> ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,3):`:3:yaml:::::]",
+        "[text(3,3):def:\n   - ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-block-quote:::True]",
+    ]
+    expected_gfm = """<blockquote>
+<p>abc</p>
+<pre><code class="language-yaml">def:
+   - ghi
+</code></pre>
+</blockquote>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09c():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   ```yaml
+   def:
+1. ghi
+   ```"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,4):`:3:yaml:::::]",
+        "[text(3,4):def::]",
+        "[end-fcode-block::::True]",
+        "[li(4,1):3::1]",
+        "[para(4,4):]",
+        "[text(4,4):ghi:]",
+        "[end-para:::False]",
+        "[fcode-block(5,4):`:3::::::]",
+        "[end-fcode-block::::True]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<pre><code class="language-yaml">def:
+</code></pre>
+</li>
+<li>ghi
+<pre><code></code></pre>
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09d():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  ```yaml
+  def:
+- ghi
+  ```"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,3):`:3:yaml:::::]",
+        "[text(3,3):def::]",
+        "[end-fcode-block::::True]",
+        "[li(4,1):2::]",
+        "[para(4,3):]",
+        "[text(4,3):ghi:]",
+        "[end-para:::False]",
+        "[fcode-block(5,3):`:3::::::]",
+        "[end-fcode-block::::True]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<pre><code class="language-yaml">def:
+</code></pre>
+</li>
+<li>ghi
+<pre><code></code></pre>
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09e():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   ```yaml
+   def:
+   1. ghi
+   ```"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,4):`:3:yaml:::::]",
+        "[text(3,4):def:\n1. ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<pre><code class="language-yaml">def:
+1. ghi
+</code></pre>
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_09f():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  ```yaml
+  def:
+  - ghi
+  ```"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,3):`:3:yaml:::::]",
+        "[text(3,3):def:\n- ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<pre><code class="language-yaml">def:
+- ghi
+</code></pre>
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_10x():
+    """
+    Test case extra 10
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   ```yaml
+   def:
+   > ghi
+   ```"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,4):`:3:yaml:::::]",
+        "[text(3,4):def:\n\a>\a&gt;\a ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<pre><code class="language-yaml">def:
+&gt; ghi
+</code></pre>
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_fenced_code_blocks_extra_10a():
+    """
+    Test case extra 10
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  ```yaml
+  def:
+  > ghi
+  ```"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[fcode-block(2,3):`:3:yaml:::::]",
+        "[text(3,3):def:\n\a>\a&gt;\a ghi:]",
+        "[end-fcode-block:::3:False]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<pre><code class="language-yaml">def:
+&gt; ghi
+</code></pre>
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)

--- a/test/gfm/test_markdown_html_blocks.py
+++ b/test/gfm/test_markdown_html_blocks.py
@@ -2335,3 +2335,325 @@ def test_html_blocks_extra_07():
 
     # Act & Assert
     act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08x():
+    """
+    Test case extra 08
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   <!-- comment
+   def:
+      - ghi
+   -->"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,4)]",
+        "[text(2,4):<!-- comment\ndef:\n   - ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<!-- comment
+def:
+   - ghi
+-->
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08a():
+    """
+    Test case extra 08
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  <!-- comment
+  def:
+     - ghi
+  -->"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,3)]",
+        "[text(2,3):<!-- comment\ndef:\n   - ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<!-- comment
+def:
+   - ghi
+-->
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08b():
+    """
+    Test case extra 08
+    """
+
+    # Arrange
+    source_markdown = """> abc
+> <!-- comment
+> def:
+>    - ghi
+> -->"""
+    expected_tokens = [
+        "[block-quote(1,1)::> \n> \n> \n> \n> ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,3)]",
+        "[text(2,3):<!-- comment\ndef:\n   - ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-block-quote:::True]",
+    ]
+    expected_gfm = """<blockquote>
+<p>abc</p>
+<!-- comment
+def:
+   - ghi
+-->
+</blockquote>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08c():
+    """
+    Test case extra 08
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   <!-- comment
+   def:
+1. ghi
+   -->"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,4)]",
+        "[text(2,4):<!-- comment\ndef::]",
+        "[end-html-block:::True]",
+        "[li(4,1):3::1]",
+        "[para(4,4):\n]",
+        "[text(4,4):ghi\n--\a>\a&gt;\a::\n]",
+        "[end-para:::True]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<!-- comment
+def:
+</li>
+<li>ghi
+--&gt;</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08d():
+    """
+    Test case extra 08
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  <!-- comment
+  def:
+- ghi
+  -->"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,3)]",
+        "[text(2,3):<!-- comment\ndef::]",
+        "[end-html-block:::True]",
+        "[li(4,1):2::]",
+        "[para(4,3):\n]",
+        "[text(4,3):ghi\n--\a>\a&gt;\a::\n]",
+        "[end-para:::True]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<!-- comment
+def:
+</li>
+<li>ghi
+--&gt;</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08e():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   <!-- comment
+   def:
+   1. ghi
+   -->"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,4)]",
+        "[text(2,4):<!-- comment\ndef:\n1. ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<!-- comment
+def:
+1. ghi
+-->
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_08f():
+    """
+    Test case extra 08
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  <!-- comment
+  def:
+  - ghi
+  -->"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,3)]",
+        "[text(2,3):<!-- comment\ndef:\n- ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<!-- comment
+def:
+- ghi
+-->
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_09x():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """1. abc
+   <!-- comment
+   def:
+   > ghi
+   -->"""
+    expected_tokens = [
+        "[olist(1,1):.:1:3::   \n   \n   \n   ]",
+        "[para(1,4):]",
+        "[text(1,4):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,4)]",
+        "[text(2,4):<!-- comment\ndef:\n> ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-olist:::True]",
+    ]
+    expected_gfm = """<ol>
+<li>abc
+<!-- comment
+def:
+> ghi
+-->
+</li>
+</ol>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
+def test_html_blocks_extra_09a():
+    """
+    Test case extra 09
+    """
+
+    # Arrange
+    source_markdown = """- abc
+  <!-- comment
+  def:
+  > ghi
+  -->"""
+    expected_tokens = [
+        "[ulist(1,1):-::2::  \n  \n  \n  ]",
+        "[para(1,3):]",
+        "[text(1,3):abc:]",
+        "[end-para:::False]",
+        "[html-block(2,3)]",
+        "[text(2,3):<!-- comment\ndef:\n> ghi\n-->:]",
+        "[end-html-block:::False]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<ul>
+<li>abc
+<!-- comment
+def:
+> ghi
+-->
+</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)

--- a/test/resources/rules/md031/bad_issue_626.md
+++ b/test/resources/rules/md031/bad_issue_626.md
@@ -1,0 +1,16 @@
+# Steps
+
+1. First
+
+    ```yaml
+    ---
+    apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+    ```
+
+2. Create
+
+    ```yaml
+    ---
+    resources:
+        - ../../base/git-common
+    ```

--- a/test/rules/test_md031.py
+++ b/test/rules/test_md031.py
@@ -791,3 +791,36 @@ def test_md031_bad_fenced_block_in_list_in_block_quote():
     execute_results.assert_results(
         expected_output, expected_error, expected_return_code
     )
+
+
+@pytest.mark.rules
+def test_md031_issue_626():
+    """
+    Addressing an issue reported in https://github.com/jackdewinter/pymarkdown/issues/626 .
+    """
+
+    # Arrange
+    scanner = MarkdownScanner()
+    source_path = os.path.join(
+        "test",
+        "resources",
+        "rules",
+        "md031",
+        "bad_issue_626.md",
+    )
+    supplied_arguments = [
+        "scan",
+        source_path,
+    ]
+
+    expected_return_code = 0
+    expected_output = ""
+    expected_error = ""
+
+    # Act
+    execute_results = scanner.invoke_main(arguments=supplied_arguments)
+
+    # Assert
+    execute_results.assert_results(
+        expected_output, expected_error, expected_return_code
+    )

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1964,6 +1964,35 @@ stdin:1:6: MD047: Each file should end with a single newline character. (single-
     )
 
 
+def test_markdown_with_scan_stdin_with_triggers_and_disabled_rules():
+    """
+    Test to make sure
+    """
+
+    # Arrange
+    scanner = MarkdownScanner()
+    supplied_arguments = [
+        "-d",
+        "MD022, MD047",
+        "scan-stdin",
+    ]
+
+    supplied_standard_input = "# test"
+    expected_return_code = 0
+    expected_output = ""
+    expected_error = ""
+
+    # Act
+    execute_results = scanner.invoke_main(
+        arguments=supplied_arguments, standard_input_to_use=supplied_standard_input
+    )
+
+    # Assert
+    execute_results.assert_results(
+        expected_output, expected_error, expected_return_code
+    )
+
+
 def test_markdown_with_scan_stdin_with_bad_write():
     """
     Test to make sure


### PR DESCRIPTION
related to #625 

this adds stripping of whitespaces, allowing [ -d, "md001,md002", scan] to be equivalent to [ -d, "md001, md002", scan]