### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1302

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -10,7 +10,9 @@
 <!--- pyml disable-next-line no-duplicate-heading-->
 ### Fixed
 
-- None
+- [Issue 1302](https://github.com/jackdewinter/pymarkdown/issues/1302)
+    - reported issue where `C\#` at the end of a header was triggering
+      rule Md020 for no spaces between end mark of an Atx Heading
 
 <!--- pyml disable-next-line no-duplicate-heading-->
 ### Changed

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1244,7 +1244,7 @@
         },
         {
             "name": "test.rules.test_md020",
-            "totalTests": 36,
+            "totalTests": 40,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1620,7 +1620,7 @@
         },
         {
             "name": "test.test_markdown_extra",
-            "totalTests": 315,
+            "totalTests": 317,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 11,

--- a/pymarkdown/plugins/rule_md_020.py
+++ b/pymarkdown/plugins/rule_md_020.py
@@ -96,7 +96,9 @@ class RuleMd020(RulePlugin):
             assert self.__last_atx_token is not None
             if self.__is_in_normal_atx and self.__last_atx_token.is_text:
                 text_token = cast(TextMarkdownToken, self.__last_atx_token)
-                if text_token.token_text.endswith("#"):
+                if text_token.token_text.endswith(
+                    "#"
+                ) and not text_token.token_text.endswith("\\\b#"):
                     regex_match = re.search(r"\#+$", text_token.token_text)
                     assert regex_match is not None
                     self.report_next_token_error(

--- a/test/rules/test_md020.py
+++ b/test/rules/test_md020.py
@@ -3,1325 +3,361 @@ Module to provide tests related to the MD020 rule.
 """
 
 import os
-from test.markdown_scanner import MarkdownScanner
-from test.rules.utils import execute_query_configuration_test, pluginQueryConfigTest
+from test.rules.utils import (
+    calculate_scan_tests,
+    execute_query_configuration_test,
+    execute_scan_test,
+    id_test_plug_rule_fn,
+    pluginQueryConfigTest,
+    pluginRuleTest,
+)
 
 import pytest
+
+source_path = os.path.join("test", "resources", "rules", "md020") + os.sep
 
 # pylint: disable=too-many-lines
 
 
-@pytest.mark.rules
-def test_md020_good_start_spacing():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings with proper spacing.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "good_start_spacing.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_good_start_spacing_in_list():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings with proper spacing in a list.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "good_start_spacing_in_list.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_good_start_spacing_in_block_quote():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings with proper spacing in a block quote.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "good_start_spacing_in_block_quote.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_ignore_bad_atx_spacing():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Headings that are not closed.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "ignore_bad_atx_spacing.md"
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md018",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_start_spacing():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the start.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_start_spacing.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_start_spacing_in_list():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the start,
-    in a list.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_start_spacing_in_list.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:4: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:4: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_start_spacing_in_block_quotes():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the start
-    in block quotes.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "missing_start_spacing_in_block_quotes.md",
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md009,md027",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_end_spacingx():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the end.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_end_spacing.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:12: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:13: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_end_spacing_in_list():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the end in a list.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_end_spacing_in_list.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:15: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:16: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_end_spacing_in_block_quotes():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the end in a block quote.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_end_spacing_in_block_quotes.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:14: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:15: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_good_almost_missing_end_spacing():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Headings that might be Atx Closed, except for
-    extra characters after the last #
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "almost_missing_end_spacing.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_both_spacing():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the
-    start and the end.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_both_spacing.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_both_spacing_in_list():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the
-    start and the end in a list.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_both_spacing_in_list.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:4: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:4: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_missing_both_spacing_in_block_quotes():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings with missing spacing at the
-    start and the end in block quotes.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "missing_both_spacing_in_block_quotes.md"
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md009,md027",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_good_with_setext_headings():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings within a SetExt heading.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "with_setext_headings.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_good_with_code_blocks():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings within a code block.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "with_code_blocks.md"
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md046",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_good_with_html_blocks():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings within a HTML block.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "with_html_blocks.md"
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md033,PML100",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "multiple_within_paragraph.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:2:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_codespan():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the code span.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_codespan.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_codespan_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multi line code span.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_codespan_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:4:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_inline_codespan_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of code span.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_inline_codespan_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_inline_rawhtml_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of raw html.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_inline_rawhtml_multi.md",
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md033",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_inline_image_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of inline images.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_inline_image_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:8:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_full_image_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of full images.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_full_image_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:5:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_shortcut_image_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of shortcut images.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_shortcut_image_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_collapsed_image_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of collapsed images.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_collapsed_image_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_inline_link_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of inline links.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_inline_link_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:8:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_full_link_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of full links.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_full_link_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:5:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_separated_shortcut_link_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of separated links.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_shortcut_link_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_collapsed_link_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by the multiple types of collapsed links.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_collapsed_link_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_multiple_within_paragraph_separated_inline_hardbreak_multi():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    separated by at least one hard line break.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "multiple_within_paragraph_separated_inline_hardbreak_multi.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:3:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_paragraphs_with_starting_whitespace():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    with increasing starting whitespace.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md020", "paragraphs_with_starting_whitespace.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:2: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:5:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:7:4: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_single_paragraph_with_starting_whitespace():
-    """
-    Test to make sure this rule does trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    with increasing starting whitespace.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "single_paragraph_with_starting_whitespace.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:2:2: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:3:3: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-        + f"{source_path}:4:4: "
-        + "MD020: No space present inside of the hashes on a possible Atx Closed Heading. "
-        + "(no-missing-space-closed-atx)\n"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_single_paragraph_with_whitespace_at_start():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    including tabbed whitespace at the start of the heading.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "single_paragraph_with_whitespace_at_start.md",
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md010,md021,md022,md023",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md020_bad_single_paragraph_with_whitespace_at_end():
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains multiple Atx Closed Headings within a paragraph
-    including tabbed whitespace at the end of the heading.
-
-    This function is shadowed by test_api_scan_with_multiple_scan_issues.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md020",
-        "single_paragraph_with_whitespace_at_end.md",
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md010,md021,md022,md023",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
+scanTests = [
+    pluginRuleTest(
+        "good_start_spacing",
+        source_file_name=f"{source_path}good_start_spacing.md",
+        source_file_contents="""# Heading 1 #
+
+## Heading 2 ##
+""",
+    ),
+    pluginRuleTest(
+        "good_start_spacing_in_list",
+        source_file_name=f"{source_path}good_start_spacing_in_list.md",
+        source_file_contents="1. # Heading 1 #\n\n2. ## Heading 2 ##\n",
+    ),
+    pluginRuleTest(
+        "good_start_spacing_in_block_quote",
+        source_file_name=f"{source_path}good_start_spacing_in_block_quote.md",
+        source_file_contents="> # Heading 1 #\n>\n> ## Heading 2 ##\n",
+    ),
+    pluginRuleTest(
+        "bad_ignore_bad_atx_spacing",
+        source_file_name=f"{source_path}ignore_bad_atx_spacing.md",
+        source_file_contents="#Heading 1\n\n##Heading 2\n",
+        disable_rules="md018",
+    ),
+    pluginRuleTest(
+        "bad_missing_start_spacing",
+        source_file_name=f"{source_path}missing_start_spacing.md",
+        source_file_contents="#Heading 1 #\n\n##Heading 2 #\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_start_spacing_in_list",
+        source_file_name=f"{source_path}missing_start_spacing_in_list.md",
+        source_file_contents="1. #Heading 1 #\n\n2. ##Heading 2 #\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:4: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:4: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_start_spacing_in_block_quotes",
+        source_file_name=f"{source_path}missing_start_spacing_in_block_quotes.md",
+        source_file_contents="> #Heading 1 #\n> \n> ##Heading 2 #\n",
+        disable_rules="md009,md027",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_end_spacingx",
+        source_file_name=f"{source_path}missing_end_spacing.md",
+        source_file_contents="# Heading 1#\n\n## Heading 2#\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:12: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:13: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_end_spacing_in_list",
+        source_file_name=f"{source_path}missing_end_spacing_in_list.md",
+        source_file_contents="1. # Heading 1#\n\n1. ## Heading 2##\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:15: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:16: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_end_spacing_in_block_quotes",
+        source_file_name=f"{source_path}missing_end_spacing_in_block_quotes.md",
+        source_file_contents="> # Heading 1#\n>\n> ## Heading 2#\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:14: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:15: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "good_almost_missing_end_spacing",
+        source_file_name=f"{source_path}almost_missing_end_spacing.md",
+        source_file_contents="# *Heading 1#*\n\n## *Heading 2#*\n",
+    ),
+    pluginRuleTest(
+        "bad_missing_both_spacing",
+        source_file_name=f"{source_path}missing_both_spacing.md",
+        source_file_contents="#Heading 1#\n\n##Heading 2#\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_both_spacing_in_list",
+        source_file_name=f"{source_path}missing_both_spacing_in_list.md",
+        source_file_contents="1. #Heading 1#\n\n2. ##Heading 2#\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:4: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:4: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_missing_both_spacing_in_block_quotes",
+        source_file_name=f"{source_path}missing_both_spacing_in_block_quotes.md",
+        source_file_contents="> #Heading 1#\n> \n> ##Heading 2#\n",
+        disable_rules="md009,md027",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "good_with_setext_headings",
+        source_file_name=f"{source_path}with_setext_headings.md",
+        source_file_contents="#Heading 1#\n---------\n\n##Heading 2##\n=========\n",
+    ),
+    pluginRuleTest(
+        "good_with_code_blocks",
+        source_file_name=f"{source_path}with_code_blocks.md",
+        source_file_contents="```text\n#Heading 1#\n```\n\n    ##Heading 2##\n",
+        disable_rules="md046",
+    ),
+    pluginRuleTest(
+        "good_with_html_blocks",
+        source_file_name=f"{source_path}with_html_blocks.md",
+        source_file_contents="<!--\n#Heading 1#\n-->\n\n<script>\n    ##Heading 2##\n</script>\n",
+        disable_rules="md033,PML100",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph",
+        source_file_name=f"{source_path}multiple_within_paragraph.md",
+        source_file_contents="#Heading 1 with no blank lines#\n##Heading 2 with no blank lines##\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:2:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_codespan",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_codespan.md",
+        source_file_contents="#Heading 1 with no blank lines#\n`code span`\n##Heading 2 with no blank lines##\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_codespan_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_codespan_multi.md",
+        source_file_contents="#Heading 1 with no blank lines#\n`code\nspan`\n##Heading 2 with no blank lines##\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:4:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_inline_codespan_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_inline_codespan_multi.md",
+        source_file_contents="#Heading 1 with no blank lines#`code\n span`##Heading 2 with no blank lines##\n  `code span`\n  ###Heading 3 with no blank lines###\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_inline_rawhtml_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_inline_rawhtml_multi.md",
+        source_file_contents="#Heading 1 with no blank lines#<raw\n html=0>##Heading 2 with no blank lines##\n  <raw html=0>\n  ###Heading 3 with no blank lines###\n",
+        disable_rules="md033",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_inline_image_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_inline_image_multi.md",
+        source_file_contents="#Heading 1 with no blank lines#![my\nimage](\n    https://google.com\n'tit\nle'\n)##Heading 2 with no blank lines##\n ![my image](https://google.com 'title')\n  ###Heading 3 with no blank lines##\n",
+        disable_rules="md033",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:8:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_full_image_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_full_image_multi.md",
+        source_file_contents='#Heading 1 with no blank lines#![my\nimage][foo\nbar]##Heading 2 with no blank lines##\n #![my image][foo bar]\n  ###Heading 3 with no blank lines##\n\n[FOO\nBAR]: train.jpg "train & tracks"\n[FOO BAR]: train.jpg "train & tracks"\n',
+        disable_rules="md033",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_shortcut_image_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_shortcut_image_multi.md",
+        source_file_contents='#Heading 1 with no blank lines#![foo\nbar]##Heading 2 with no blank lines##\n #![foo bar]\n  ###Heading 3 with no blank lines###\n\n[FOO\nBAR]: train.jpg "train & tracks"\n[FOO BAR]: train.jpg "train & tracks"\n',
+        disable_rules="md033",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_collapsed_image_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_collapsed_image_multi.md",
+        source_file_contents='#Heading 1 with no blank lines#![foo\nbar][]##Heading 2 with no blank lines##\n #![foo bar][]\n  ###Heading 3 with no blank lines###\n\n[FOO\nBAR]: train.jpg "train & tracks"\n[FOO BAR]: train.jpg "train & tracks"\n',
+        disable_rules="md033",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_inline_link_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_inline_link_multi.md",
+        source_file_contents="#Heading 1 with no blank lines##[my\nimage](\n    https://google.com\n'tit\nle'\n)##Heading 2 with no blank lines##\n [my image](https://google.com 'title')\n  ###Heading 3 with no blank lines##\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:8:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_full_link_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_full_link_multi.md",
+        source_file_contents='#Heading 1 with no blank lines#[my\nimage][foo\nbar]##Heading 2 with no blank lines##\n [my image][foo bar]\n  ###Heading 3 with no blank lines##\n\n[FOO\nBAR]: train.jpg "train & tracks"\n[FOO BAR]: train.jpg "train & tracks"\n',
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_separated_shortcut_link_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_shortcut_link_multi.md",
+        source_file_contents='#Heading 1 with no blank lines#[foo\nbar]##Heading 2 with no blank lines##\n [foo bar]\n  ###Heading 3 with no blank lines###\n\n[FOO\nBAR]: train.jpg "train & tracks"\n[FOO BAR]: train.jpg "train & tracks"\n',
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_collapsed_link_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_collapsed_link_multi.md",
+        source_file_contents='#Heading 1 with no blank lines#[foo\nbar][]##Heading 2 with no blank lines##\n [foo bar][]\n  ###Heading 3 with no blank lines###\n\n[FOO\nBAR]: train.jpg "train & tracks"\n[FOO BAR]: train.jpg "train & tracks"\n',
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_multiple_within_paragraph_separated_inline_hardbreak_multi",
+        source_file_name=f"{source_path}multiple_within_paragraph_separated_inline_hardbreak_multi.md",
+        source_file_contents="#Heading 1 with no blank lines#\\\n ##Heading 2 with no blank lines##  \n  ###Heading 3 with no blank lines###\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_paragraphs_with_starting_whitespace",
+        source_file_name=f"{source_path}paragraphs_with_starting_whitespace.md",
+        source_file_contents="#Heading 1#\n\n ##Heading 2##\n\n  ###Heading 3###\n\n   ####Heading 4####\n\n    #####Heading 5#####\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:2: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:5:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:7:4: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_single_paragraph_with_starting_whitespace",
+        source_file_name=f"{source_path}single_paragraph_with_starting_whitespace.md",
+        source_file_contents="#Heading 1#\n ##Heading 2##\n  ###Heading 3###\n   ####Heading 4####\n    #####Heading 5#####\n",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:2:2: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:3:3: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+{temp_source_path}:4:4: MD020: No space present inside of the hashes on a possible Atx Closed Heading. (no-missing-space-closed-atx)
+""",
+    ),
+    pluginRuleTest(
+        "bad_single_paragraph_with_whitespace_at_start",
+        source_file_name=f"{source_path}single_paragraph_with_whitespace_at_start.md",
+        source_file_contents="#\tHeading 1 #\n ##\tHeading 2 ##\n",
+        disable_rules="md010,md021,md022,md023",
+    ),
+    pluginRuleTest(
+        "bad_single_paragraph_with_whitespace_at_end",
+        source_file_name=f"{source_path}single_paragraph_with_whitespace_at_end.md",
+        source_file_contents="# Heading 1\t#\n ## Heading 2\t##\n",
+        disable_rules="md010,md021,md022,md023",
+    ),
+    pluginRuleTest(
+        "issue-1302-primary",
+        source_file_contents="""# MD020
+
+<!-- Escaped hash at end of line -->
+
+## Intro to C\\#
+
+Emits MD020 warning.
+
+<!-- Escaped hash followed by punctuation -->
+
+### Intro to C\\#, continued
+
+Emits nothing.
+
+<!--  Escaped hash followed by a space -->
+
+## Intro to C\\# programming
+
+Emits nothing.
+""",
+    ),
+    pluginRuleTest(
+        "issue-1302-secondary",
+        source_file_contents="""## Intro to C&#35;
+
+Emits MD020 warning.
+""",
+    ),
+    pluginRuleTest(
+        "issue-1302-tertiary-1",
+        source_file_contents="""\\# Intro to C++
+
+Emits MD020 warning.
+""",
+    ),
+    pluginRuleTest(
+        "issue-1302-tertiary-2",
+        source_file_contents="""&#35; Intro to C++
+
+Emits MD020 warning.
+""",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test", calculate_scan_tests(scanTests), ids=id_test_plug_rule_fn
+)
+def test_md020_scan(test: pluginRuleTest) -> None:
+    """
+    Execute a parameterized scan test for plugin md020.
+    """
+    execute_scan_test(test, "md020")
 
 
 def test_md020_query_config():

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -15732,7 +15732,64 @@ list 2</li>
 
     # Act & Assert
     act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
-    # assert False
+
+
+@pytest.mark.gfm
+def test_extra_053a0():
+    """
+    TBD
+    issue-1302
+    """
+
+    # Arrange
+    source_markdown = """## Intro to C\\#
+
+Emits MD020 warning.
+"""
+    expected_tokens = [
+        "[atx(1,1):2:0:]",
+        "[text(1,4):Intro to C\\\b#: ]",
+        "[end-atx::]",
+        "[BLANK(2,1):]",
+        "[para(3,1):]",
+        "[text(3,1):Emits MD020 warning.:]",
+        "[end-para:::True]",
+        "[BLANK(4,1):]",
+    ]
+    expected_gfm = """<h2>Intro to C#</h2>
+<p>Emits MD020 warning.</p>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
+def test_extra_053a1():
+    """
+    TBD
+    issue-1302
+    """
+
+    # Arrange
+    source_markdown = """## Intro to C&#35;
+
+Emits MD020 warning.
+"""
+    expected_tokens = [
+        "[atx(1,1):2:0:]",
+        "[text(1,4):Intro to C\a&#35;\a#\a: ]",
+        "[end-atx::]",
+        "[BLANK(2,1):]",
+        "[para(3,1):]",
+        "[text(3,1):Emits MD020 warning.:]",
+        "[end-para:::True]",
+        "[BLANK(4,1):]",
+    ]
+    expected_gfm = """<h2>Intro to C#</h2>
+<p>Emits MD020 warning.</p>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
 
 
 @pytest.mark.gfm


### PR DESCRIPTION
Addressed https://github.com/jackdewinter/pymarkdown/issues/1302

## Summary by Sourcery

Fix handling of escaped hashes at the end of Atx Closed Headings.

Bug Fixes:
- Fixed a bug where escaped hashes at the end of Atx Closed Headings were incorrectly triggering the MD020 rule.

Tests:
- Added test cases for escaped hashes at the end of Atx Closed Headings.