### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1326

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -23,6 +23,9 @@
 - [Issue 1302](https://github.com/jackdewinter/pymarkdown/issues/1302)
     - reported issue where `C\#` at the end of a header was triggering
       rule Md020 for no spaces between end mark of an Atx Heading
+- [Issue 1326](https://github.com/jackdewinter/pymarkdown/issues/1326)
+    - fix mode for MD012 not properly handling double lines in lists after
+      new list indicators
 
 <!--- pyml disable-next-line no-duplicate-heading-->
 ### Changed

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -2,12 +2,12 @@
     "projectName": "pymarkdown",
     "reportSource": "pytest",
     "branchLevel": {
-        "totalMeasured": 7983,
-        "totalCovered": 7983
+        "totalMeasured": 7985,
+        "totalCovered": 7985
     },
     "lineLevel": {
-        "totalMeasured": 21590,
-        "totalCovered": 21590
+        "totalMeasured": 21597,
+        "totalCovered": 21597
     }
 }
 

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1204,7 +1204,7 @@
         },
         {
             "name": "test.rules.test_md012",
-            "totalTests": 78,
+            "totalTests": 96,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1620,7 +1620,7 @@
         },
         {
             "name": "test.test_markdown_extra",
-            "totalTests": 317,
+            "totalTests": 318,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 11,

--- a/pymarkdown/plugins/rule_md_012.py
+++ b/pymarkdown/plugins/rule_md_012.py
@@ -272,4 +272,6 @@ class RuleMd012(RulePlugin):
             self.__leading_space_index_tracker.open_container(token)
         elif token.is_block_quote_end or token.is_list_end:
             self.__leading_space_index_tracker.register_container_end(token)
+        elif token.is_new_list_item:
+            self.__leading_space_index_tracker.nudge_list_container(token)
         self.__leading_space_index_tracker.track_since_last_non_end_token(token)

--- a/pymarkdown/plugins/utils/leading_space_index_tracker.py
+++ b/pymarkdown/plugins/utils/leading_space_index_tracker.py
@@ -19,6 +19,7 @@ class ClosedContainerAdjustments:
     adjustment: int = 0
     count: int = 0
     count2: int = 0
+    list_nudge_count: int = 0
 
 
 class LeadingSpaceIndexTracker:
@@ -49,6 +50,14 @@ class LeadingSpaceIndexTracker:
         assert token.is_block_quote_start or token.is_list_start
         self.__container_token_stack.append(token)
         self.__closed_container_adjustments.append(ClosedContainerAdjustments())
+
+    def nudge_list_container(self, token: MarkdownToken) -> None:
+        assert token.is_new_list_item
+        assert (
+            self.__container_token_stack
+            and self.__container_token_stack[-1].is_list_start
+        )
+        self.__closed_container_adjustments[-1].list_nudge_count += 1
 
     def register_container_end(self, token: MarkdownToken) -> None:
         """
@@ -224,7 +233,10 @@ class LeadingSpaceIndexTracker:
             LeadingSpaceIndexTracker.calculate_token_line_number(token)
             - self.get_container_stack_item(initial_index).line_number
         )
-        index -= last_closed_container_info.adjustment
+        index -= (
+            last_closed_container_info.adjustment
+            + last_closed_container_info.list_nudge_count
+        )
         index -= adjust
         return index
 

--- a/test/rules/test_md012.py
+++ b/test/rules/test_md012.py
@@ -306,6 +306,25 @@ My 10 lines
 1. barney
 """,
     ),
+    pluginRuleTest(
+        "bad_in_list_with_new_list_with_double_blanks_at_middle",
+        source_file_contents="""1. betty
+1. fred
+
+
+   fred2
+1. barney
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        disable_rules="md009",
+        fix_expected_file_contents="""1. betty
+1. fred
+
+   fred2
+1. barney
+""",
+    ),
     pluginRuleTest(  # test_extra_051a1
         "bad_in_list_with_double_blanks_at_start",
         source_file_contents="""1.
@@ -329,6 +348,36 @@ My 10 lines
         fix_expected_file_contents="""1. fred
 
 1. barney
+""",
+    ),
+    pluginRuleTest(
+        "bad_in_list_with_newlist_with_double_blanks_at_end",
+        source_file_contents="""1. fred
+1. barney
+
+
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 3] (no-multiple-blanks)""",
+        disable_rules="md009",
+        fix_expected_file_contents="""1. fred
+1. barney
+""",
+    ),
+    pluginRuleTest(
+        "bad_in_list_with_double_newlist_with_double_blanks_at_end",
+        source_file_contents="""1. fred
+1. barney
+1. betty
+
+
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:6:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 3] (no-multiple-blanks)""",
+        disable_rules="md009",
+        fix_expected_file_contents="""1. fred
+1. barney
+1. betty
 """,
     ),
     pluginRuleTest(
@@ -540,24 +589,39 @@ My 10 lines
         source_file_contents="""+ 1.
 
      fred2
-+ 1. barney
+  1. barney
 """,
         scan_expected_return_code=0,
         disable_rules="md009",
     ),
     pluginRuleTest(
-        "bad_in_list_in_list_with_double_blanks_at_end",
+        "bad_in_list_in_list_with_newlist_with_double_blanks_at_end",
         source_file_contents="""+ 1. fred
+  1. barney
 
 
-+ 1. barney
 """,
         scan_expected_return_code=1,
-        scan_expected_output="""{temp_source_path}:3:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        scan_expected_output="""{temp_source_path}:5:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 3] (no-multiple-blanks)""",
         disable_rules="md009",
         fix_expected_file_contents="""+ 1. fred
+  1. barney
+""",
+    ),
+    pluginRuleTest(
+        "bad_in_list_in_list_with_double_newlist_with_double_blanks_at_end",
+        source_file_contents="""+ 1. fred
+  1. barney
+  1. betty
 
-+ 1. barney
+
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:6:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 3] (no-multiple-blanks)""",
+        disable_rules="md009",
+        fix_expected_file_contents="""+ 1. fred
+  1. barney
+  1. betty
 """,
     ),
     pluginRuleTest(
@@ -613,7 +677,6 @@ My 10 lines
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:4:2: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 3] (no-multiple-blanks)""",
         disable_rules="md009",
-        # use_fix_debug=True,
         fix_expected_file_contents="""> 1. fred
 >
 >    fred2
@@ -666,6 +729,187 @@ My 10 lines
 >
 >    fred3
 > 1. barney
+""",
+    ),
+    pluginRuleTest(
+        "issue-1326-a",
+        source_file_contents="""# z
+
+z
+
+
+
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+
+-   z
+</div>
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:7:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 4] (no-multiple-blanks)
+{temp_source_path}:14:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        disable_rules="md030,md032,md033",
+        fix_expected_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+</div>
+""",
+    ),
+    pluginRuleTest(
+        "issue-1326-b",
+        source_file_contents="""# z
+
+z
+
+
+
+
+<div class="grid cards" markdown>
+
+-   z
+
+
+-   z
+
+-   z
+</div>
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:7:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 4] (no-multiple-blanks)
+{temp_source_path}:12:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        disable_rules="md030,md032,md033",
+        fix_expected_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+</div>
+""",
+    ),
+    pluginRuleTest(
+        "issue-1326-c",
+        source_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+
+-   z
+
+-   z
+</div>
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:9:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        disable_rules="md030,md032,md033",
+        fix_expected_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+</div>
+""",
+    ),
+    pluginRuleTest(
+        "issue-1326-d",
+        source_file_contents="""# z
+
+z
+
+
+
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+
+
+</div>
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:7:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 4] (no-multiple-blanks)
+{temp_source_path}:16:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        disable_rules="md030,md032,md033",
+        fix_expected_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+
+</div>
+""",
+    ),
+    pluginRuleTest(
+        "issue-1326-e",
+        source_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+
+
+</div>
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:13:1: MD012: Multiple consecutive blank lines [Expected: 1, Actual: 2] (no-multiple-blanks)""",
+        disable_rules="md030,md032,md033",
+        fix_expected_file_contents="""# z
+
+z
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+-   z
+
+</div>
 """,
     ),
 ]

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -15793,6 +15793,88 @@ Emits MD020 warning.
 
 
 @pytest.mark.gfm
+def test_extra_053b0():
+    """
+    TBD
+    issue-1326
+    """
+
+    # Arrange
+    source_markdown = """# z
+
+z
+
+
+
+
+<div class="grid cards" markdown>
+
+-   z
+
+-   z
+
+
+-   z
+</div>
+"""
+    expected_tokens = [
+        "[atx(1,1):1:0:]",
+        "[text(1,3):z: ]",
+        "[end-atx::]",
+        "[BLANK(2,1):]",
+        "[para(3,1):]",
+        "[text(3,1):z:]",
+        "[end-para:::True]",
+        "[BLANK(4,1):]",
+        "[BLANK(5,1):]",
+        "[BLANK(6,1):]",
+        "[BLANK(7,1):]",
+        "[html-block(8,1)]",
+        '[text(8,1):<div class="grid cards" markdown>:]',
+        "[end-html-block:::False]",
+        "[BLANK(9,1):]",
+        "[ulist(10,1):-::4::\n\n]",
+        "[para(10,5):]",
+        "[text(10,5):z:]",
+        "[end-para:::True]",
+        "[BLANK(11,1):]",
+        "[li(12,1):4::]",
+        "[para(12,5):]",
+        "[text(12,5):z:]",
+        "[end-para:::True]",
+        "[BLANK(13,1):]",
+        "[BLANK(14,1):]",
+        "[li(15,1):4::]",
+        "[para(15,5):]",
+        "[text(15,5):z:]",
+        "[end-para:::True]",
+        "[end-ulist:::True]",
+        "[html-block(16,1)]",
+        "[text(16,1):</div>:]",
+        "[end-html-block:::False]",
+        "[BLANK(17,1):]",
+    ]
+    expected_gfm = """<h1>z</h1>
+<p>z</p>
+<div class="grid cards" markdown>
+<ul>
+<li>
+<p>z</p>
+</li>
+<li>
+<p>z</p>
+</li>
+<li>
+<p>z</p>
+</li>
+</ul>
+</div>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+
+
+@pytest.mark.gfm
 def test_extra_999():
     """
     Temporary test to keep coverage up while consistency checks disabled.


### PR DESCRIPTION
https://github.com/jackdewinter/pymarkdown/issues/1326

## Summary by Sourcery

Fix handling of double blank lines within list items for MD012.

Bug Fixes:
- Fixed an issue where MD012 was not correctly handling multiple blank lines within list items, especially after new list item indicators.

Tests:
- Added test cases to verify the fix for MD012.