### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1380

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -13,6 +13,8 @@
 - [Issue 1379](https://github.com/jackdewinter/pymarkdown/issues/1379)
     - Fixed rehydration issues for test_extra_052l\* and test_extra_052m\*
     - Precursor for addressing the fix mode Md031 tests
+- [Issue 1380](https://github.com/jackdewinter/pymarkdown/issues/1380)
+    - Fixing the 2 Md031 tests now unblocked from Issue 1379
 
 <!--- pyml disable-next-line no-duplicate-heading-->
 ### Changed

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -2,12 +2,12 @@
     "projectName": "pymarkdown",
     "reportSource": "pytest",
     "branchLevel": {
-        "totalMeasured": 8071,
-        "totalCovered": 8071
+        "totalMeasured": 8079,
+        "totalCovered": 8079
     },
     "lineLevel": {
-        "totalMeasured": 21827,
-        "totalCovered": 21826
+        "totalMeasured": 21845,
+        "totalCovered": 21844
     }
 }
 

--- a/publish/pylint_suppression.json
+++ b/publish/pylint_suppression.json
@@ -329,7 +329,8 @@
             "too-many-instance-attributes": 1
         },
         "pymarkdown/plugins/rule_md_031.py": {
-            "too-many-instance-attributes": 1
+            "too-many-instance-attributes": 1,
+            "too-many-boolean-expressions": 1
         },
         "pymarkdown/plugins/rule_md_032.py": {},
         "pymarkdown/plugins/rule_md_033.py": {},
@@ -515,7 +516,7 @@
         "too-many-arguments": 256,
         "too-many-locals": 50,
         "chained-comparison": 3,
-        "too-many-boolean-expressions": 6,
+        "too-many-boolean-expressions": 7,
         "protected-access": 25,
         "deprecated-decorator": 3,
         "broad-exception-caught": 3,

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1156,10 +1156,10 @@
         },
         {
             "name": "test.rules.test_md005",
-            "totalTests": 94,
+            "totalTests": 93,
             "failedTests": 0,
             "errorTests": 0,
-            "skippedTests": 1,
+            "skippedTests": 0,
             "elapsedTimeInMilliseconds": 0
         },
         {
@@ -1367,7 +1367,7 @@
             "totalTests": 657,
             "failedTests": 0,
             "errorTests": 0,
-            "skippedTests": 17,
+            "skippedTests": 15,
             "elapsedTimeInMilliseconds": 0
         },
         {

--- a/pymarkdown/plugins/utils/leading_space_index_tracker.py
+++ b/pymarkdown/plugins/utils/leading_space_index_tracker.py
@@ -51,13 +51,18 @@ class LeadingSpaceIndexTracker:
         self.__container_token_stack.append(token)
         self.__closed_container_adjustments.append(ClosedContainerAdjustments())
 
-    def nudge_list_container(self, token: MarkdownToken) -> None:
-        assert token.is_new_list_item
-        assert (
-            self.__container_token_stack
-            and self.__container_token_stack[-1].is_list_start
-        )
-        self.__closed_container_adjustments[-1].list_nudge_count += 1
+    def nudge_list_container(
+        self, token: MarkdownToken, nudge_positive: bool = True
+    ) -> None:
+        if nudge_positive:
+            assert token.is_new_list_item
+            assert (
+                self.__container_token_stack
+                and self.__container_token_stack[-1].is_list_start
+            )
+            self.__closed_container_adjustments[-1].list_nudge_count += 1
+        else:
+            self.__closed_container_adjustments[-1].list_nudge_count -= 1
 
     def register_container_end(self, token: MarkdownToken) -> None:
         """

--- a/test/rules/test_md031.py
+++ b/test/rules/test_md031.py
@@ -7208,7 +7208,7 @@ another list
 """,
     ),
     pluginRuleTest(  # test_extra_052l0 test_extra_052l01 NONCOMP1
-        "bad_fenced_block_in_list_in_list_in_block_quote_with_previous_list_double_drop",
+        "bad_fenced_block_in_list_in_list_in_block_quote_with_previous_list_double_drop_x",
         source_file_contents="""> + + -----
 >     + list 1
 >       list 2
@@ -7223,8 +7223,7 @@ another list
         scan_expected_output="""{temp_source_path}:5:5: MD031: Fenced code blocks should be surrounded by blank lines (blanks-around-fences)
 {temp_source_path}:7:5: MD031: Fenced code blocks should be surrounded by blank lines (blanks-around-fences)
 """,
-        disable_rules="md032",
-        mark_fix_as_skipped=skip_fix_bad_markdown,
+        disable_rules="md032,md027",
         use_debug=True,
         fix_expected_file_contents="""> + + -----
 >     + list 1
@@ -7348,9 +7347,8 @@ another list
         scan_expected_output="""{temp_source_path}:6:5: MD031: Fenced code blocks should be surrounded by blank lines (blanks-around-fences)
 {temp_source_path}:8:5: MD031: Fenced code blocks should be surrounded by blank lines (blanks-around-fences)
 """,
-        disable_rules="md032",
+        disable_rules="md032,md027",
         use_debug=True,
-        mark_fix_as_skipped=skip_fix_bad_markdown,
         fix_expected_file_contents="""> + + -----
 >     + list 1
 >       list 2

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -14856,7 +14856,7 @@ list 2</li>
 </blockquote>"""
 
     # Act & Assert
-    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=True)
 
 
 @pytest.mark.gfm
@@ -14935,7 +14935,7 @@ list 2</li>
 </blockquote>"""
 
     # Act & Assert
-    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=False)
+    act_and_assert(source_markdown, expected_gfm, expected_tokens, show_debug=True)
 
 
 @pytest.mark.gfm
@@ -16467,17 +16467,6 @@ def test_extra_999():
     assert new_front_matter.is_extension
 
     ParserHelper.count_newlines_in_texts("text")
-
-
-# NONCOMP1
-# bad_fenced_block_in_list_in_list_in_block_quote_with_previous_list_double_drop
-# Expected:> + + -----\n>     + list 1\n>       list 2\n>     + list 3\n>\n>   ```block\n>   A code block\n>   ```\n>\n>   -----\n> + another list\n:
-#   Actual:> + + -----\n>     + list 1\n>       list 2\n>     + list 3\n> \n> ```block\n> A code block\n> ```\n>  \n> -----\n> + another list\n:
-
-# NONCOMP2
-# bad_fenced_block_in_list_in_list_in_block_quote_with_previous_list_double_drop_and_thematics
-# Expected:> + + -----\n>     + list 1\n>       list 2\n>     + list 3\n>   -----\n>\n>   ```block\n>   A code block\n>   ```\n>\n>   -----\n> + another list\n:
-#   Actual:> + + -----\n>     + list 1\n>       list 2\n>     + list 3\n> -----\n>\n> ```block\n>   A code block\n> ```\n>\n> -----\n> + another list\n:
 
 
 # FOOBAR1 bad_fenced_block_in_list_in_block_quote_in_block_quote_with_previous_list_triple_drop_and_thematics


### PR DESCRIPTION
https://github.com/jackdewinter/pymarkdown/issues/1380

## Summary by Sourcery

Addresses issues with list spacing and fenced code blocks within nested block quotes and lists, specifically fixing edge cases in the application of rule MD031. The changes involve adjustments to how leading spaces are tracked and modified during the fixing process, especially when dealing with nested containers and list nudging.

Bug Fixes:
- Fixes edge cases in the application of rule MD031 related to list spacing and fenced code blocks within nested block quotes and lists.

Enhancements:
- Improves the accuracy of leading space adjustments in nested list and block quote scenarios by refining the logic for tracking and modifying leading spaces.
- Enhances the `nudge_list_container` function to allow for both positive and negative nudges, providing more flexibility in adjusting list indentation.

Tests:
- Adds and modifies tests to cover the fixed scenarios, ensuring the correct rendering of Markdown with nested lists, block quotes, and fenced code blocks.