### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1426

### DIFF
--- a/newdocs/src/plugins/rule_md032.md
+++ b/newdocs/src/plugins/rule_md032.md
@@ -60,6 +60,81 @@ is found directly within the scope of another List element. If
 a List element is found directly within the scope of a Block
 Quote element, then this rule behaves normally.
 
+#### Additional Scenarios - Paragraphs and Indented Code Blocks
+
+Due to the [GitHub Flavored Markdown](https://github.github.com/gfm/) specification's
+there are three scenarios that appear to be violations of this rule, but are not. In
+all of these scenarios, if the text on line four is not meant to be part of the list,
+an inserted blank line will properly convey that intent to most parsers.
+
+The first scenario is the text:
+
+````Markdown
+This is text and a blank line.
+
++ a list
+This is some text.
+````
+
+Because of the specification's use of [Lazy Continuation Lines](https://github.github.com/gfm/#example-268),
+the fourth line in the above example is considered a "lazy" continuation of
+the list started on line three. Essentially, the list has a single list item
+with the text `a list This is some text.`.  
+
+The second scenario is following a list with an indented code block:
+
+````Markdown
+This is text and a blank line.
+
++ a list
+    This is some text.
+````
+
+While there may be the writer's intent to follow the list with an indented code
+block, most parsers will clearly see line four as a continuation of the list
+started on line three, but with two extrace spaces of indentation.
+
+#### Additional Scenarios - Multiline Leaf Elements
+
+Finally, the third scenario is any list that is followed by a multiline leaf element,
+such as the link reference definition element, the setext Headings element, or the
+table element. As noted in the first two scenarios, having plain text that does
+not explicitly start a new container block or leaf block usually causes the parsers
+to assume that the plain text is part of the list itself.  In that situation, most
+parsers explicitly check to see if that new line is part of a list continuation
+or if a new element has been specified.
+
+In the case of multiline elements, it is difficult to determine from a single line
+whether a given multiline element is valid.  While the following example:
+
+````Markdown
++ a list
+
+[lrd]:
+/url
+````
+
+is clearly a list element followed by a link reference definition (due to the newline
+between the two), the following example creates doubt as to the correct parsing of the
+example:
+
+````Markdown
++ a list
+[lrd]:
+/url
+````
+
+To properly parse this, our parser and other parsers would need to mark their position
+and state, parse the possible link reference definition, restoring the marked position
+and state if the parsing failed.  As the majority of parsers do not perform that
+extra level of care, our parser follows that majority and assumes that lines two
+and three are part of the list started on line one.
+
+It therefore follows that if our parser treats that scenario as a continuation of the
+list item, this rule sees a single list item with nothing after it.  Therefore,
+the rule does not trigger in this scenario and reduces to be in the same set as
+the first scenario in the previous section.
+
 ## Fix Description
 
 The auto-fix feature for this rule is scheduled to be added soon after the v1.0.0

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1372,7 +1372,7 @@
         },
         {
             "name": "test.rules.test_md032",
-            "totalTests": 16,
+            "totalTests": 30,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1620,7 +1620,7 @@
         },
         {
             "name": "test.test_markdown_extra",
-            "totalTests": 328,
+            "totalTests": 329,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 2,

--- a/test/rules/test_md032.py
+++ b/test/rules/test_md032.py
@@ -3,508 +3,354 @@ Module to provide tests related to the MD032 rule.
 """
 
 import os
-from test.markdown_scanner import MarkdownScanner
-from test.rules.utils import execute_query_configuration_test, pluginQueryConfigTest
+from test.rules.utils import (
+    execute_query_configuration_test,
+    execute_scan_test,
+    id_test_plug_rule_fn,
+    pluginQueryConfigTest,
+    pluginRuleTest,
+)
 
 import pytest
 
+source_path = os.path.join("test", "resources", "rules", "md032") + os.sep
 
-@pytest.mark.rules
-def test_md032_good_list_surrounded() -> None:
+scanTests = [
+    pluginRuleTest(
+        "good_list_surrounded",
+        source_file_name=f"{source_path}good_list_surrounded.md",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+
+This is a blank line and some text.
+""",
+    ),
+    pluginRuleTest(
+        "good_list_at_start",
+        source_file_name=f"{source_path}good_list_at_start.md",
+        source_file_contents="""+ a list
+
+This is a blank line and some text.
+""",
+    ),
+    pluginRuleTest(
+        "good_list_at_end",
+        source_file_name=f"{source_path}good_list_at_end.md",
+        source_file_contents="""This is text and a blank line.
+
++ a list""",
+        disable_rules="md047",
+    ),
+    pluginRuleTest(
+        "bad_list_before",
+        source_file_name=f"{source_path}bad_list_before.md",
+        source_file_contents="""This is text.
++ a list
+
+This is a blank line and some text.
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:2:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+""",
+    ),
+    pluginRuleTest(
+        "bad_list_after",
+        source_file_name=f"{source_path}bad_list_after.md",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+# This is any non-text block
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "bad_block_quote_list_block_quote",
+        source_file_name=f"{source_path}bad_block_quote_list_block_quote.md",
+        source_file_contents="""> this is a block quote
++ a list
++ still a list
+> this is a block quote
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:2:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+""",
+    ),
+    pluginRuleTest(
+        "bad_other_list_list_other_list",
+        source_file_name=f"{source_path}bad_other_list_list_other_list.md",
+        source_file_contents="""1. this is a block quote
++ a list
++ still a list
+1. this is a block quote
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+{temp_source_path}:2:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+""",
+    ),
+    pluginRuleTest(
+        "good_list_within_list_surrounded",
+        source_file_name=f"{source_path}good_list_within_list_surrounded.md",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+  + a sublist
+
+This is a blank line and some text.
+""",
+    ),
+    pluginRuleTest(
+        "good_list_within_block_quote_surrounded",
+        source_file_name=f"{source_path}good_list_within_block_quote_surrounded.md",
+        source_file_contents="""This is text and a blank line.
+
+> + a list
+
+This is a blank line and some text.
+""",
+    ),
+    pluginRuleTest(
+        "bad_list_within_block_quote_surrounded",
+        source_file_name=f"{source_path}bad_list_within_block_quote_surrounded.md",
+        source_file_contents="""This is text and a blank line.
+
+> a block quote
+> + a list
+
+This is a blank line and some text.
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:3: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+""",
+    ),
+    pluginRuleTest(
+        "good_nested_lists",
+        source_file_name=f"{source_path}good_nested_lists.md",
+        source_file_contents="""These are nested lists.
+
+- some text at level 1
+- some more text at level 1
+  - some text at level 2
+- yet more text at level 1
+  - some text at level 2
+""",
+    ),
+    pluginRuleTest(
+        "good_list_levels_1_2_3_2_1",
+        source_file_name=f"{source_path}good_list_levels_1_2_3_2_1.md",
+        source_file_contents="""# title
+
+- 1
+  - 1.1
+    - 1.1.1
+  - 1.2
+- 2
+""",
+    ),
+    pluginRuleTest(
+        "good_list_levels_1_2_3_space_1",
+        source_file_name=f"{source_path}good_list_levels_1_2_3_space_1.md",
+        source_file_contents="""# title
+
+- 1
+  - 1.1
+    - 1.1.1
+
+- 2
+""",
+    ),
+    pluginRuleTest(
+        "good_list_levels_1_2_3_1",
+        source_file_name=f"{source_path}good_list_levels_1_2_3_1.md",
+        source_file_contents="""# title
+
+- 1
+  - 1.1
+    - 1.1.1
+- 2
+""",
+    ),
+    pluginRuleTest(
+        "bad_fenced_block_in_list_in_block_quote",
+        source_file_name=f"{source_path}bad_fenced_block_in_list_in_block_quote.md",
+        source_file_contents="""> + list
+> ```block
+> A code block
+> ```
+> 1. another list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:3: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+{temp_source_path}:5:3: MD032: Lists should be surrounded by blank lines (blanks-around-lists)
+""",
+        disable_rules="md031",
+    ),
+    pluginRuleTest(  # https://github.github.com/gfm/#example-268
+        "issue-1426-a-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+This is any non-text block
+""",
+    ),
+    pluginRuleTest(
+        "issue-1426-a-b",
+        source_file_contents="""This is text and a blank line.
+
+This is any non-text block
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+    ),
+    pluginRuleTest(
+        "issue-1426-b-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+## This is any non-text block
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-b-b",
+        source_file_contents="""This is text and a blank line.
+
+## This is any non-text block
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-c-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+------
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-c-b",
+        source_file_contents="""This is text and a blank line.
+
+------
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-d-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+```Markdown
+# blah
+```
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022,md031",
+    ),
+    pluginRuleTest(
+        "issue-1426-d-b",
+        source_file_contents="""This is text and a blank line.
+
+```Markdown
+# blah
+```
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:6:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022,md031",
+    ),
+    pluginRuleTest(  # https://github.github.com/gfm/#example-268 - just more spaces instead of less
+        "issue-1426-e-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+    blah
+""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-e-b",
+        source_file_contents="""This is text and a blank line.
+
+    blah
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(  # https://github.github.com/gfm/#example-268 - variation
+        "issue-1426-f-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+[blah]: /url
+""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-f-b",
+        source_file_contents="""This is text and a blank line.
+
+[blah]: /url
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-g-a",
+        source_file_contents="""This is text and a blank line.
+
++ a list
+<!-- blah -->
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+    pluginRuleTest(
+        "issue-1426-g-b",
+        source_file_contents="""This is text and a blank line.
+
+<!-- blah -->
++ a list
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:4:1: MD032: Lists should be surrounded by blank lines (blanks-around-lists)""",
+        disable_rules="md022",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", scanTests, ids=id_test_plug_rule_fn)
+def test_md032_scan(test: pluginRuleTest) -> None:
     """
-    Test to make sure this rule does not trigger with a document that
-    contains lists surrounded by blank lines.
+    Execute a parameterized scan test for plugin md001.
     """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_surrounded.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_at_start() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains lists surrounded by blank lines at the very start of the document.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_at_start.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_at_end() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains lists surrounded by blank lines at the very end of the document.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_at_end.md"
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md047",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_bad_list_before() -> None:
-    """
-    Test to make sure this rule does trigger with a document that
-    contains a list that does not have a blank line before it.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "bad_list_before.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:2:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_bad_list_after() -> None:
-    """
-    Test to make sure this rule does trigger with a document that
-    contains a list that does not have a blank line after it.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "bad_list_after.md"
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md022",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:3:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_bad_block_quote_list_block_quote() -> None:
-    """
-    Test to make sure this rule does trigger with a document that
-    contains a list that has a block quote directly before and after it.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "bad_block_quote_list_block_quote.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:2:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)\n"
-        + f"{source_path}:3:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_bad_other_list_list_other_list() -> None:
-    """
-    Test to make sure this rule does trigger with a document that
-    contains a list that has another list before and after it.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "bad_other_list_list_other_list.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)\n"
-        + f"{source_path}:2:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)\n"
-        + f"{source_path}:3:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)\n"
-        + f"{source_path}:4:1: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_within_list_surrounded() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains a 2-level list with blank lines before and after.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_within_list_surrounded.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_within_block_quote_surrounded() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains a list inside of a block quote surrounded by blank lines.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md032",
-        "good_list_within_block_quote_surrounded.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_bad_list_within_block_quote_surrounded() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains a list within a block quote that is immediately after a text line
-    within the block quote.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md032",
-        "bad_list_within_block_quote_surrounded.md",
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:4:3: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_nested_lists() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains nested lists with proper blank lines around.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_nested_lists.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_levels_1_2_3_2_1() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains deeper nested lists with proper blank lines around.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_levels_1_2_3_2_1.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_levels_1_2_3_space_1() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains more complex nested lists with proper blank lines around.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_levels_1_2_3_space_1.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_good_list_levels_1_2_3_1() -> None:
-    """
-    Test to make sure this rule does not trigger with a document that
-    contains nested lists with proper blank lines around.  With a 2 level
-    drop.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test", "resources", "rules", "md032", "good_list_levels_1_2_3_1.md"
-    )
-    supplied_arguments = [
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 0
-    expected_output = ""
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
-
-
-@pytest.mark.rules
-def test_md032_bad_fenced_block_in_list_in_block_quote() -> None:
-    """
-    Test to make sure this rule does trigger with a document that
-    contains lists on either side of a fenced code block with no blank lines.
-    """
-
-    # Arrange
-    scanner = MarkdownScanner()
-    source_path = os.path.join(
-        "test",
-        "resources",
-        "rules",
-        "md032",
-        "bad_fenced_block_in_list_in_block_quote.md",
-    )
-    supplied_arguments = [
-        "--disable-rules",
-        "md031",
-        "scan",
-        source_path,
-    ]
-
-    expected_return_code = 1
-    expected_output = (
-        f"{source_path}:1:3: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)\n"
-        + f"{source_path}:5:3: "
-        + "MD032: Lists should be surrounded by blank lines (blanks-around-lists)"
-    )
-    expected_error = ""
-
-    # Act
-    execute_results = scanner.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(
-        expected_output, expected_error, expected_return_code
-    )
+    execute_scan_test(test, "md032")
 
 
 def test_md032_query_config() -> None:

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -16485,6 +16485,40 @@ def test_extra_054x() -> None:
 
 
 @pytest.mark.gfm
+def test_extra_055x() -> None:
+    """
+    TBD
+    """
+
+    # Arrange
+    source_markdown = """This is text and a blank line.
+
++ a list
+[blah]: /url
+"""
+    expected_tokens = [
+        "[para(1,1):]",
+        "[text(1,1):This is text and a blank line.:]",
+        "[end-para:::True]",
+        "[BLANK(2,1):]",
+        "[ulist(3,1):+::2::\n]",
+        "[para(3,3):\n]",
+        "[text(3,3):a list\n[blah]: /url::\n]",
+        "[end-para:::True]",
+        "[BLANK(5,1):]",
+        "[end-ulist:::True]",
+    ]
+    expected_gfm = """<p>This is text and a blank line.</p>
+<ul>
+<li>a list
+[blah]: /url</li>
+</ul>"""
+
+    # Act & Assert
+    act_and_assert(source_markdown, expected_gfm, expected_tokens)
+
+
+@pytest.mark.gfm
 def test_extra_999() -> None:
     """
     Temporary test to keep coverage up while consistency checks disabled.


### PR DESCRIPTION
## Summary by Sourcery

Refactor and enhance the MD032 rule test suite by consolidating tests into a parameterized format, add extensive edge-case coverage for issue #1426, update the rule documentation with additional parsing scenarios, and introduce a new GFM compliance test for list and link reference handling.

Enhancements:
- Refactor MD032 rule tests to use a unified parameterized pluginRuleTest approach
- Add comprehensive edge-case scenarios for rule MD032 (issue #1426) to the parameterized test suite
- Introduce execute_scan_test and id_test_plug_rule_fn utilities for streamlined test execution
- Add a new GFM compliance test_extra_055x to validate list and link reference parsing

Documentation:
- Extend MD032 rule documentation with additional scenarios for paragraphs, indented code blocks, and multiline leaf elements

Tests:
- Replace individual MD032 tests with a parameterized scanTests list
- Add new parameterized test cases covering various list-continuation and blank-line edge cases