### PR TITLE
[drive-by] Brush-up/modernize the packaging portion of CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Twine
         run: |
           export PYTHONIOENCODING=utf-8
-          pipenv run twine check dist/*    
+          pipenv run twine check --strict dist/*    
 
       - name: Upload Package
         uses: actions/upload-artifact@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,7 +259,7 @@ jobs:
     needs: [packaging]
     name: Publish Python 🐍 distribution 📦 to PyPI
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     environment:
       name: pypi
       url: https://pypi.org/p/pymarkdownlnt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,7 +255,7 @@ jobs:
           path: ${{github.workspace}}/dist/
 
   publish-to-pypi:
-    # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/
+    # See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
     needs: [packaging]
     name: Publish Python 🐍 distribution 📦 to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Setup
         run: |
           export PYTHONIOENCODING=utf-8
-          pipenv run python setup.py sdist bdist_wheel
+          pipenv run python -Im build
 
       - name: Twine
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,7 +254,7 @@ jobs:
           name: packaged-library
           path: ${{github.workspace}}/dist/
 
-  publish-to-testpypi:
+  publish-to-pypi:
     # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/
     needs: [packaging]
     name: Publish Python 🐍 distribution 📦 to PyPI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,5 +271,5 @@ jobs:
       with:
         name: python-package-dist
         path: dist/
-    - name: Publish distribution 📦 to TestPyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+  'setuptools',
+]
+build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
This includes cleaning outdated referenced to TestPyPI, updating the canonical doc URL, enabling stricter checks, getting rid of deprecated build entry point in favor or standardized PEP 517 interface and using modern context refs @ GHA.

## Summary by Sourcery

Modernize the packaging steps in CI/CD by adopting PEP 517 builds, enabling stricter checks, and updating the PyPI publish workflow

Enhancements:
- Replace legacy setup.py commands with python -Im build
- Enable strict mode in twine check
- Rename and reconfigure the publish job to target PyPI with updated trigger and context
- Update GitHub Actions documentation links and contexts for packaging
- Add pyproject.toml with a PEP 517 build-system section