### PR TITLE
[drive-by][CI] Use a built-in `${GITHUB_REF_NAME}` env var in CI instead of parsing complex values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,8 @@ jobs:
     - name: Calculate test matrix
       id: set-matrix
       run: |
-        branchName=$(echo '${{ github.ref }}' | sed 's,refs/heads/,,g')
-        echo "Branch Name: $branchName"
-        matrix=$(jq --arg branchName "$branchName" 'map(. | select((.runOn==$branchName) or (.runOn=="current")) )' .github/workflows/matrix_includes.json)
+        echo "Branch Name: ${GITHUB_REF_NAME}"
+        matrix=$(jq --arg branchName "${GITHUB_REF_NAME}" 'map(. | select((.runOn==$GITHUB_REF_NAME) or (.runOn=="current")) )' .github/workflows/matrix_includes.json)
         echo "Matrix: $matrix"
         echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
 
@@ -60,9 +59,8 @@ jobs:
     - name: Calculate test matrix
       id: set-matrix
       run: |
-        branchName=$(echo '${{ github.ref }}' | sed 's,refs/heads/,,g')
-        echo "Branch Name: $branchName"
-        matrix=$(jq --arg branchName "$branchName" 'map(. | select((.runOn==$branchName) or (.runOn=="previous")) )' .github/workflows/matrix_includes.json)
+        echo "Branch Name: ${GITHUB_REF_NAME}"
+        matrix=$(jq --arg branchName "${GITHUB_REF_NAME}" 'map(. | select((.runOn==$GITHUB_REF_NAME) or (.runOn=="previous")) )' .github/workflows/matrix_includes.json)
         echo "Matrix: $matrix"
         echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       id: set-matrix
       run: |
         echo "Branch Name: ${GITHUB_REF_NAME}"
-        matrix=$(jq --arg branchName "${GITHUB_REF_NAME}" 'map(. | select((.runOn==$GITHUB_REF_NAME) or (.runOn=="current")) )' .github/workflows/matrix_includes.json)
+        matrix=$(jq --arg branchName "${GITHUB_REF_NAME}" 'map(. | select((.runOn==$branchName) or (.runOn=="current")) )' .github/workflows/matrix_includes.json)
         echo "Matrix: $matrix"
         echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
 
@@ -60,7 +60,7 @@ jobs:
       id: set-matrix
       run: |
         echo "Branch Name: ${GITHUB_REF_NAME}"
-        matrix=$(jq --arg branchName "${GITHUB_REF_NAME}" 'map(. | select((.runOn==$GITHUB_REF_NAME) or (.runOn=="previous")) )' .github/workflows/matrix_includes.json)
+        matrix=$(jq --arg branchName "${GITHUB_REF_NAME}" 'map(. | select((.runOn==$branchName) or (.runOn=="previous")) )' .github/workflows/matrix_includes.json)
         echo "Matrix: $matrix"
         echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary by Sourcery

Simplify branch name extraction in GitHub Actions by replacing manual parsing of `github.ref` with the built-in `GITHUB_REF_NAME` environment variable in test matrix jobs

CI:
- Use `GITHUB_REF_NAME` instead of sed-based parsing of `github.ref` in matrix calculation
- Update `jq` filters to reference `GITHUB_REF_NAME` for selecting appropriate test matrix entries