### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1475

### DIFF
--- a/newdocs/src/advanced_configuration.md
+++ b/newdocs/src/advanced_configuration.md
@@ -331,7 +331,7 @@ Previously exposed for testing purposes, the PyMarkdown linter now provides the
 ability to selectively enable rules using a command line like:
 
 ```bash
-pymarkdown -e Md041 -d * scan .
+pymarkdown -e Md041 -d "*" scan .
 ```
 
 This command line instructs the application to disable all rules, enabling only

--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -14,7 +14,8 @@
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Fixed
 
-- None
+- [Issue 1475](https://github.com/jackdewinter/pymarkdown/issues/1475)
+    - fixed typo in documentation
 
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Changed


### PR DESCRIPTION
https://github.com/jackdewinter/pymarkdown/issues/1475

## Summary by Sourcery

Fix documentation typo as per issue 1475 and correct the CLI example in the advanced configuration guide by quoting the wildcard argument

Documentation:
- Add changelog entry for issue 1475 noting the documentation typo fix
- Update advanced configuration guide to quote the wildcard argument in the CLI example