### PR TITLE
docs: fix typo (seperate → separate)

### DIFF
--- a/xxx.md
+++ b/xxx.md
@@ -1037,7 +1037,7 @@ some other text
 """
 ```
 
-### `test_tables_extension_extra_in_list_header_line_only_with_separator_in_seperate_list_item`
+### `test_tables_extension_extra_in_list_header_line_only_with_separator_in_separate_list_item`
 
 ```python
     source_markdown = """- | foo | bar |


### PR DESCRIPTION
Fixes a typo in `xxx.md`: `seperate` → `separate`.

This is a minor documentation fix with no functional changes.

## Summary by Sourcery

Documentation:
- Fix a spelling error in a test case heading in the markdown documentation.