### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1568

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -42,6 +42,11 @@
 - [Issue 1566](https://github.com/jackdewinter/pymarkdown/issues/1566)
     - change of indent in list causes issues, making calculations wrong
       for following elements
+- [Issue 1568](https://github.com/jackdewinter/pymarkdown/issues/1568)
+    - Md046 and Md031 can both fix fenced blocks, so moved to different
+      fix levels
+    - added extra check to make sure that if two fenced code blocks are
+      one after the other, first one fixed spacing, not both
 - [Issue 1569](https://github.com/jackdewinter/pymarkdown/issues/1569)
     - whitespace was reported in both the list and the paragraph with
       nested containers

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -2,12 +2,12 @@
     "projectName": "pymarkdown",
     "reportSource": "Unknown",
     "branchLevel": {
-        "totalMeasured": 5868,
-        "totalCovered": 5868
+        "totalMeasured": 5870,
+        "totalCovered": 5870
     },
     "lineLevel": {
-        "totalMeasured": 23534,
-        "totalCovered": 23534
+        "totalMeasured": 23540,
+        "totalCovered": 23540
     }
 }
 

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1372,7 +1372,7 @@
         },
         {
             "name": "test.rules.test_md031",
-            "totalTests": 657,
+            "totalTests": 661,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 15,

--- a/pymarkdown/file_scan_helper.py
+++ b/pymarkdown/file_scan_helper.py
@@ -470,7 +470,7 @@ class FileScanHelper:
         per_file_disabled_identifiers: Optional[Set[str]],
     ) -> Tuple[bool, bool, int]:
         keep_processing = False
-        collect_list = []
+        collect_list: List[str] = []
         fix_list = []
         for fix_level, level_list in plugins_by_fix_level.items():
             if fix_level == minimum_fix_level:

--- a/pymarkdown/plugins/rule_md_031.py
+++ b/pymarkdown/plugins/rule_md_031.py
@@ -68,6 +68,8 @@ class RuleMd031(RulePlugin):
         self.__container_adjustments: List[List[PendingContainerAdjustment]] = []
         self.__container_x: List[int] = []
 
+        self.__submitted_fix = False
+
         self.__fix_count = 0
         self.__removed_container_stack_token: Optional[MarkdownToken] = None
         self.__x1: List[MarkdownToken] = []
@@ -97,6 +99,7 @@ class RuleMd031(RulePlugin):
             plugin_url="https://pymarkdown.readthedocs.io/en/latest/plugins/rule_md031.md",
             plugin_configuration="list_items",
             plugin_supports_fix=True,
+            plugin_fix_level=3,
         )
 
     def initialize_from_config(self) -> None:
@@ -218,7 +221,7 @@ class RuleMd031(RulePlugin):
         new_token.adjust_line_number(context, self.__fix_count)
 
         assert self.__second_last_token is not None
-        replacement_tokens = [
+        replacement_tokens: List[MarkdownToken] = [
             BlankLineMarkdownToken(
                 extracted_whitespace="",
                 position_marker=PositionMarker(new_token.line_number - 1, 0, ""),
@@ -227,7 +230,7 @@ class RuleMd031(RulePlugin):
             self.__last_token,
             new_token,
         ]
-        self.register_replace_tokens_request(
+        self.__replace_tokens_request(
             context, self.__second_last_token, token, replacement_tokens
         )
 
@@ -946,9 +949,7 @@ class RuleMd031(RulePlugin):
                 self.__last_end_container_tokens[end_container_index + 1 :]
             )
         replacement_tokens.append(new_token)
-        self.register_replace_tokens_request(
-            context, first_token, token, replacement_tokens
-        )
+        self.__replace_tokens_request(context, first_token, token, replacement_tokens)
 
     def __fix_spacing_with_special_list_fix(
         self, context: PluginScanContext, token: MarkdownToken, new_token: MarkdownToken
@@ -956,7 +957,7 @@ class RuleMd031(RulePlugin):
         assert self.__last_token and self.__last_token.is_block_quote_end
         new_end_token = cast(EndMarkdownToken, copy.copy(self.__last_token))
         new_end_token.set_extra_end_data(None)
-        replacement_tokens = [
+        replacement_tokens: List[MarkdownToken] = [
             BlankLineMarkdownToken(
                 extracted_whitespace="",
                 position_marker=PositionMarker(new_token.line_number - 1, 0, ""),
@@ -965,14 +966,14 @@ class RuleMd031(RulePlugin):
             new_end_token,
             new_token,
         ]
-        self.register_replace_tokens_request(
+        self.__replace_tokens_request(
             context, self.__last_token, token, replacement_tokens
         )
 
     def __fix_spacing_with_else(
         self, context: PluginScanContext, token: MarkdownToken, new_token: MarkdownToken
     ) -> None:
-        replacement_tokens = [
+        replacement_tokens: List[MarkdownToken] = [
             BlankLineMarkdownToken(
                 extracted_whitespace="",
                 position_marker=PositionMarker(new_token.line_number - 1, 0, ""),
@@ -980,7 +981,21 @@ class RuleMd031(RulePlugin):
             ),
             new_token,
         ]
-        self.register_replace_tokens_request(context, token, token, replacement_tokens)
+
+        self.__replace_tokens_request(context, token, token, replacement_tokens)
+
+    def __replace_tokens_request(
+        self,
+        context: PluginScanContext,
+        start_token: MarkdownToken,
+        end_token: MarkdownToken,
+        replacement_tokens: List[MarkdownToken],
+    ) -> None:
+        if not self.__submitted_fix:
+            self.register_replace_tokens_request(
+                context, start_token, end_token, replacement_tokens
+            )
+            self.__submitted_fix = True
 
     def __calc_kludge_one(self, at_least_one_container: bool) -> bool:
         if not at_least_one_container:
@@ -1372,6 +1387,10 @@ class RuleMd031(RulePlugin):
         """
         Event that a new token is being processed.
         """
+
+        # There are special cases where this rule tries to submit 2 fixes for the same token,
+        # especially in the scenario where two fenced code blocks are one after another with no blank line in between.
+        self.__submitted_fix = False
 
         special_case, special_case_2 = self.__calculate_specials(context, token)
         if not token.is_end_token or token.is_end_of_stream:

--- a/test/rules/test_md031.py
+++ b/test/rules/test_md031.py
@@ -9321,6 +9321,50 @@ another list
 """,
         scan_expected_return_code=0,
     ),
+    pluginRuleTest(
+        "issue-1568-a",
+        source_file_contents="""```text
+...
+```
+
+    ```text
+    tscom2.masterdata.zkServers=awfuxtccap01p:5301,awfuxtccap02p:5301,awfuxtccap03p:5301,awfuxtccap04p:5301,awfuxtccap05p:5301,awfuxtccap06p:5301
+    ```
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:5: MD046: Code block style [Expected: fenced; Actual: indented] (code-block-style)
+""",
+        fix_expected_file_contents="""```text
+...
+```
+
+```
+```text
+tscom2.masterdata.zkServers=awfuxtccap01p:5301,awfuxtccap02p:5301,awfuxtccap03p:5301,awfuxtccap04p:5301,awfuxtccap05p:5301,awfuxtccap06p:5301
+```
+
+```
+""",
+        # use_fix_debug=True,
+        # use_fix_file_debug=True
+    ),
+    pluginRuleTest(
+        "issue-1568-b",
+        source_file_contents="""```text
+```
+```text
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:2:1: MD031: Fenced code blocks should be surrounded by blank lines (blanks-around-fences)
+{temp_source_path}:3:1: MD031: Fenced code blocks should be surrounded by blank lines (blanks-around-fences)
+""",
+        fix_expected_file_contents="""```text
+```
+
+```text
+""",
+        # use_fix_debug=True
+    ),
 ]
 
 

--- a/test/rules/utils.py
+++ b/test/rules/utils.py
@@ -45,6 +45,7 @@ class pluginRuleTest:
     use_debug: bool = False
     use_strict_config: bool = False
     use_fix_debug: bool = False
+    use_fix_file_debug: bool = False
     disable_rules: str = ""
     enable_rules: str = ""
     enable_extensions: str = ""
@@ -126,6 +127,8 @@ def build_arguments(
             supplied_arguments.extend(("--disable-rules", test.disable_rules))
 
         if is_fix:
+            if test.use_fix_file_debug:
+                supplied_arguments.append("-x-fix-file-debug")
             if test.use_fix_debug:
                 supplied_arguments.append("-x-fix-debug")
             supplied_arguments.extend(("fix", temp_source_path))


### PR DESCRIPTION
## Summary by Sourcery

Adjust MD031 fenced code block spacing fixes to avoid conflicting or duplicate fixes when adjacent fenced blocks are present, and align rule fix levels and test utilities accordingly.

Bug Fixes:
- Prevent MD031 from submitting multiple conflicting fix requests for the same token when two fenced code blocks appear consecutively without a blank line.
- Resolve interaction between MD031 and MD046 by assigning MD031 to a higher fix level so both rules can safely fix fenced blocks.

Enhancements:
- Add a helper in MD031 to centralize replace-token fix submission and gate it so only one fix is submitted per token.
- Extend test utilities with a flag to enable fix-file debugging output.
- Annotate internal collections and variables with explicit list typing for clarity and type checking.
- Document the MD031/MD046 fix-level change and adjacent fenced block fix behavior in the changelog.

Tests:
- Add regression tests covering issue 1568 scenarios, including adjacent fenced code blocks and fenced/indented code combinations that previously produced incorrect or duplicated fixes.

Chores:
- Tighten typing in file scan helper fix-level processing for collected fix output.