### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1604

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -5,6 +5,10 @@
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Added
 
+- [Issue 1604](https://github.com/jackdewinter/pymarkdown/issues/1604)
+    - Fixed issue where not properly keeping track of table tokens with rule Md013,
+      resulting in the rule getting "stuck" on tables, ignoring anything after
+      that point in the document
 - [Issue 1605](https://github.com/jackdewinter/pymarkdown/issues/1605)
     - Add support for native file format lists in JSON, YAML, TOML
         - [`plugins.per-file-ignores`](./advanced_configuration.md#per-file-disabling-of-rule-plugins)

--- a/pymarkdown/plugins/rule_md_013.py
+++ b/pymarkdown/plugins/rule_md_013.py
@@ -164,6 +164,7 @@ class RuleMd013(RulePlugin):
         """
         Event that a new line is being processed.
         """
+
         if (
             self.__leaf_token_index + 1 < len(self.__leaf_tokens)
             and self.__line_index
@@ -215,7 +216,12 @@ class RuleMd013(RulePlugin):
         Event that a new token is being processed.
         """
         _ = context
-        if token.is_blank_line or token.is_leaf:
+        if (token.is_blank_line or token.is_leaf) and not (
+            token.is_table_header_item
+            or token.is_table_row_item
+            or token.is_table_body
+            or token.is_table
+        ):
             self.__leaf_tokens.append(token)
 
 

--- a/pymarkdown/tokens/markdown_token.py
+++ b/pymarkdown/tokens/markdown_token.py
@@ -484,6 +484,13 @@ class MarkdownToken:
         return self.token_name == self.token_name == MarkdownToken._token_table_row
 
     @property
+    def is_table_body(self) -> bool:
+        """
+        Returns whether the current token is a body from a table.
+        """
+        return self.token_name == self.token_name == MarkdownToken._token_table_body
+
+    @property
     def is_table_row_item(self) -> bool:
         """
         Returns whether the current token is a row item from a table.

--- a/test/rules/test_md013.py
+++ b/test/rules/test_md013.py
@@ -3,9 +3,11 @@ Module to provide tests related to the MD013 rule.
 """
 
 import os
+import tempfile
 from test.markdown_scanner import MarkdownScanner
 from test.pytest_execute import ExpectedResults
 from test.rules.utils import execute_query_configuration_test, pluginQueryConfigTest
+from test.utils import write_temporary_configuration
 from typing import Tuple
 
 import pytest
@@ -1230,6 +1232,61 @@ def test_md013_bad_html_block_with_config(scanner_default: MarkdownScanner) -> N
 
     # Assert
     execute_results.assert_results(expected_results=expected_results)
+
+
+@pytest.mark.rules
+def test_md013_issue_1604(scanner_default: MarkdownScanner) -> None:
+    """
+    Test to make sure this rule does not trigger with a document that
+    contains a long line within a HTML block, but configuration to allow
+    it.
+    """
+
+    # Arrange
+    markdown_content = """# Test
+
+this is a really long line which _should not_ be ignored because of the pymarkdown configuration.
+
+```sh
+# this is a really long line which _should_ be ignored because of the pymarkdown configuration.
+```
+
+## Test1
+
+| one | two | three |
+| --- | --- | --- |
+| four | five | this is a test |
+
+```sh
+# this is a really long line which _should_ be ignored because of the pymarkdown configuration.
+```
+"""
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir_path:
+        source_path = write_temporary_configuration(
+            markdown_content,
+            directory=tmp_dir_path,
+            file_name_suffix=".md",
+        )
+        supplied_arguments = [
+            "--set",
+            "extensions.markdown-tables.enabled=$!True",
+            "--set",
+            "plugins.MD013.code_blocks=$!False",
+            "--strict-config",
+            "scan",
+            source_path,
+        ]
+
+        expected_results = ExpectedResults(
+            return_code=1,
+            expected_output=f"""{source_path}:3:1: MD013: Line length [Expected: 80, Actual: 97] (line-length)""",
+        )
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(expected_results=expected_results)
 
 
 def test_md013_query_config() -> None:


### PR DESCRIPTION
## Summary by Sourcery

Fix MD013 line-length rule to correctly handle table tokens and add regression coverage and documentation for the resolved issue.

Bug Fixes:
- Ensure MD013 correctly tracks table-related tokens so line-length checking resumes after tables instead of silently ignoring subsequent content.

Enhancements:
- Expose a new is_table_body property on Markdown tokens to better classify table body tokens.

Documentation:
- Document the MD013 table-handling fix for issue 1604 in the changelog.

Tests:
- Add a regression test for issue 1604 verifying MD013 behavior with long lines, code blocks, and tables under specific configuration.