### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/1609

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -5,20 +5,21 @@
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Added
 
-- [Issue 1604](https://github.com/jackdewinter/pymarkdown/issues/1604)
-    - Fixed issue where not properly keeping track of table tokens with rule Md013,
-      resulting in the rule getting "stuck" on tables, ignoring anything after
-      that point in the document
 - [Issue 1605](https://github.com/jackdewinter/pymarkdown/issues/1605)
     - Add support for native file format lists in JSON, YAML, TOML
         - [`plugins.per-file-ignores`](./advanced_configuration.md#per-file-disabling-of-rule-plugins)
         - [`system.exclude_path`](./advanced_configuration.md#excluding-paths)
         - [`plugins.additional_paths`](./advanced_configuration.md#adding-rule-plugins)
+- [Issue 1609](https://github.com/jackdewinter/pymarkdown/issues/1609)
+    - Added support for `tables` and `table_line_length` for MD013:line-length
 
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Fixed
 
-- None
+- [Issue 1604](https://github.com/jackdewinter/pymarkdown/issues/1604)
+    - Fixed issue where not properly keeping track of table tokens with rule Md013,
+      resulting in the rule getting "stuck" on tables, ignoring anything after
+      that point in the document
 
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Changed

--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -17,9 +17,9 @@
 ### Fixed
 
 - [Issue 1604](https://github.com/jackdewinter/pymarkdown/issues/1604)
-    - Fixed issue where not properly keeping track of table tokens with rule Md013,
-      resulting in the rule getting "stuck" on tables, ignoring anything after
-      that point in the document
+    - Fixed an issue where the rule was not properly keeping track of table tokens
+      with rule Md013, resulting in the rule getting "stuck" on tables, ignoring
+      anything after that point in the document
 
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Changed

--- a/newdocs/src/plugins/rule_md013.md
+++ b/newdocs/src/plugins/rule_md013.md
@@ -72,7 +72,8 @@ the `heading_line_length` configuration value specifies the line length
 for headings and `headings` configuration value specifies whether this
 rule triggers at all for headings.  Similarly, the `code_block_line_length`
 and `code_blocks` configuration values perform the same action for
-code blocks.
+code blocks and the `table_line_length` and `tables` configuration values
+perform the same action for tables.
 
 ## Fix Description
 
@@ -86,15 +87,17 @@ release.
 | `plugins.md013.` |
 | `plugins.line-length.` |
 
-<!-- pyml disable-num-lines 10 line-length-->
+<!-- pyml disable-num-lines 12 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
 | `line_length` | `integer` | `80` | Maximum number of characters on a normal line. |
-| `heading_line_length` | `integer` | `80` | Maximum number of characters on a heading line. |
+| `code_blocks` | `boolean` | `True` | Whether the Rule Plugin triggers on lines in a code block. |
 | `code_block_line_length` | `integer` | `80` | Maximum number of characters on a code block line. |
 | `headings` | `boolean` | `True` | Whether the Rule Plugin triggers on lines in a heading. |
-| `code_blocks` | `boolean` | `True` | Whether the Rule Plugin triggers on lines in a code block. |
+| `heading_line_length` | `integer` | `80` | Maximum number of characters on a heading line. |
+| `tables` | `boolean` | `True` | Whether the Rule Plugin triggers on lines in a table. |
+| `table_line_length` | `integer` | `80` | Maximum number of characters on a table line. |
 | `stern` | `boolean` | `False` | Whether the 'stern' trigger rules are in effect. |
 | `strict` | `boolean` | `False` | Whether the 'strict' trigger rules are in effect. |
 
@@ -102,8 +105,3 @@ release.
 
 This rule is largely inspired by the MarkdownLint rule
 [MD013](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013---line-length).
-
-### Differences From MarkdownLint Rule
-
-The substantial difference from the original rule is that the `table` configuration
-value is not present as the PyMarkdown parser does not currently support tables.

--- a/pymarkdown/plugins/rule_md_013.py
+++ b/pymarkdown/plugins/rule_md_013.py
@@ -49,7 +49,7 @@ class RuleMd013(RulePlugin):
             plugin_id="MD013",
             plugin_enabled_by_default=True,
             plugin_description="Line length",
-            plugin_version="0.6.1",
+            plugin_version="0.6.2",
             plugin_url="https://pymarkdown.readthedocs.io/en/latest/plugins/rule_md013.md",
             plugin_configuration="line_length,heading_line_length,code_block_line_length,"
             + "code_blocks,headings,strict,stern",

--- a/pymarkdown/plugins/rule_md_013.py
+++ b/pymarkdown/plugins/rule_md_013.py
@@ -31,9 +31,11 @@ class RuleMd013(RulePlugin):
         self.__line_length = 0
         self.__code_block_line_length = 0
         self.__heading_line_length = 0
+        self.__table_line_length = 0
         self.__minimum_line_length = 0
         self.__code_blocks_active = False
         self.__headings_active = False
+        self.__tables_active = False
         self.__strict_mode = False
         self.__stern_mode = False
         self.__last_line: Optional[str] = None
@@ -83,10 +85,18 @@ class RuleMd013(RulePlugin):
                 valid_value_fn=self.__validate_minimum,
             )
         )
+        self.__table_line_length = (
+            self.plugin_configuration.get_integer_property_with_default(
+                "table_line_length",
+                80,
+                valid_value_fn=self.__validate_minimum,
+            )
+        )
         self.__minimum_line_length = min(
             self.__line_length,
             self.__code_block_line_length,
             self.__heading_line_length,
+            self.__table_line_length,
         )
 
         self.__code_blocks_active = (
@@ -98,6 +108,12 @@ class RuleMd013(RulePlugin):
         self.__headings_active = (
             self.plugin_configuration.get_boolean_property_with_default(
                 "headings",
+                True,
+            )
+        )
+        self.__tables_active = (
+            self.plugin_configuration.get_boolean_property_with_default(
+                "tables",
                 True,
             )
         )
@@ -118,10 +134,12 @@ class RuleMd013(RulePlugin):
         """
         return [
             QueryConfigItem("line_length", self.__line_length),
-            QueryConfigItem("code_block_line_length", self.__code_block_line_length),
-            QueryConfigItem("heading_line_length", self.__heading_line_length),
             QueryConfigItem("code_blocks", self.__code_blocks_active),
+            QueryConfigItem("code_block_line_length", self.__code_block_line_length),
             QueryConfigItem("headings", self.__headings_active),
+            QueryConfigItem("heading_line_length", self.__heading_line_length),
+            QueryConfigItem("tables", self.__tables_active),
+            QueryConfigItem("table_line_length", self.__table_line_length),
             QueryConfigItem("strict", self.__strict_mode),
             QueryConfigItem("stern", self.__stern_mode),
         ]
@@ -156,6 +174,15 @@ class RuleMd013(RulePlugin):
             compare_length = (
                 self.__heading_line_length
                 if self.__headings_active
+                else RuleMd013.__maximum_line_length
+            )
+        elif (
+            self.__leaf_tokens[self.__leaf_token_index].is_table_header
+            or self.__leaf_tokens[self.__leaf_token_index].is_table_row
+        ):
+            compare_length = (
+                self.__table_line_length
+                if self.__tables_active
                 else RuleMd013.__maximum_line_length
             )
         return line_length > compare_length, compare_length

--- a/test/rules/test_md013.py
+++ b/test/rules/test_md013.py
@@ -1235,6 +1235,177 @@ def test_md013_bad_html_block_with_config(scanner_default: MarkdownScanner) -> N
 
 
 @pytest.mark.rules
+def test_md013_good_table_line_length_not_exceeded(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure this rule does not trigger with a document that
+    contains a long line within a HTML block, but configuration to allow
+    it.
+    """
+
+    # Arrange
+    markdown_content = """the following table is less than the line length
+
+| one-two-three-four | one-two-three-four |
+| --- | --- |
+| four-five-six-seven | four-five-six-seven |
+"""
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir_path:
+        source_path = write_temporary_configuration(
+            markdown_content,
+            directory=tmp_dir_path,
+            file_name_suffix=".md",
+        )
+        supplied_arguments = [
+            "--set",
+            "extensions.markdown-tables.enabled=$!True",
+            "--set",
+            "plugins.md013.table_line_length=$#60",
+            "--strict-config",
+            "scan",
+            source_path,
+        ]
+
+        expected_results = ExpectedResults()
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(expected_results=expected_results)
+
+
+@pytest.mark.rules
+def test_md013_bad_table_line_length_exceeded(scanner_default: MarkdownScanner) -> None:
+    """
+    Test to make sure this rule does not trigger with a document that
+    contains a long line within a HTML block, but configuration to allow
+    it.
+    """
+
+    # Arrange
+    markdown_content = """
+this is a long line that is longer than sixty characters to test lengths
+
+| one-two-three-four | one-two-three-four | one-two-three-four |
+| --- | --- | --- |
+| four-five-six-seven | four-five-six-seven | four-five-six-seven |
+"""
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir_path:
+        source_path = write_temporary_configuration(
+            markdown_content,
+            directory=tmp_dir_path,
+            file_name_suffix=".md",
+        )
+        supplied_arguments = [
+            "--set",
+            "extensions.markdown-tables.enabled=$!True",
+            "--set",
+            "plugins.md013.table_line_length=$#60",
+            "--strict-config",
+            "scan",
+            source_path,
+        ]
+
+        expected_results = ExpectedResults(
+            return_code=1,
+            expected_output=f"""{source_path}:4:1: MD013: Line length [Expected: 60, Actual: 64] (line-length)
+{source_path}:6:1: MD013: Line length [Expected: 60, Actual: 67] (line-length)""",
+        )
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(expected_results=expected_results)
+
+
+@pytest.mark.rules
+def test_md013_bad_tables_enabled(scanner_default: MarkdownScanner) -> None:
+    """
+    Test to make sure this rule does not trigger with a document that
+    contains a long line within a HTML block, but configuration to allow
+    it.
+    """
+
+    # Arrange
+    markdown_content = """the following table is less than the line length
+
+| one-two-three-four | one-two-three-four | one-two-three-four | one-two-three-four |
+| --- | --- | --- | --- |
+| four-five-six-seven | four-five-six-seven | four-five-six-seven | four-five-six-seven |
+"""
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir_path:
+        source_path = write_temporary_configuration(
+            markdown_content,
+            directory=tmp_dir_path,
+            file_name_suffix=".md",
+        )
+        supplied_arguments = [
+            "--set",
+            "extensions.markdown-tables.enabled=$!True",
+            "--set",
+            "plugins.md013.tables=$!True",
+            "--strict-config",
+            "scan",
+            source_path,
+        ]
+
+        expected_results = ExpectedResults(
+            return_code=1,
+            expected_output=f"""{source_path}:3:1: MD013: Line length [Expected: 80, Actual: 85] (line-length)
+{source_path}:5:1: MD013: Line length [Expected: 80, Actual: 89] (line-length)""",
+        )
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(expected_results=expected_results)
+
+
+@pytest.mark.rules
+def test_md013_good_tables_disabled(scanner_default: MarkdownScanner) -> None:
+    """
+    Test to make sure this rule does not trigger with a document that
+    contains a long line within a HTML block, but configuration to allow
+    it.
+    """
+
+    # Arrange
+    markdown_content = """the following table is less than the line length
+
+| one-two-three-four | one-two-three-four | one-two-three-four | one-two-three-four |
+| --- | --- | --- | --- |
+| four-five-six-seven | four-five-six-seven | four-five-six-seven | four-five-six-seven |
+"""
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir_path:
+        source_path = write_temporary_configuration(
+            markdown_content,
+            directory=tmp_dir_path,
+            file_name_suffix=".md",
+        )
+        supplied_arguments = [
+            "--set",
+            "extensions.markdown-tables.enabled=$!True",
+            "--set",
+            "plugins.md013.tables=$!False",
+            "--strict-config",
+            "scan",
+            source_path,
+        ]
+
+        expected_results = ExpectedResults()
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(expected_results=expected_results)
+
+
+@pytest.mark.rules
 def test_md013_issue_1604(scanner_default: MarkdownScanner) -> None:
     """
     Test to make sure this rule does not trigger with a document that
@@ -1305,10 +1476,12 @@ def test_md013_query_config() -> None:
   CONFIGURATION ITEM      TYPE     VALUE
 
   line_length             integer  80
-  code_block_line_length  integer  80
-  heading_line_length     integer  80
   code_blocks             boolean  True
+  code_block_line_length  integer  80
   headings                boolean  True
+  heading_line_length     integer  80
+  tables                  boolean  True
+  table_line_length       integer  80
   strict                  boolean  False
   stern                   boolean  False
 """,

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -1271,7 +1271,7 @@ def test_markdown_with_plugins_list_only(scanner_default: MarkdownScanner) -> No
   md010   no-hard-tabs                    True       True       0.6.1    Yes
   md011   no-reversed-links               True       True       0.5.1    No
   md012   no-multiple-blanks              True       True       0.7.0    Yes
-  md013   line-length                     True       True       0.6.1    No
+  md013   line-length                     True       True       0.6.2    No
   md014   commands-show-output            True       True       0.5.0    No
   md018   no-missing-space-atx            True       True       0.5.1    No
   md019   no-multiple-space-atx           True       True       0.5.1    Yes
@@ -1312,7 +1312,7 @@ def test_markdown_with_plugins_list_only(scanner_default: MarkdownScanner) -> No
   md048   code-fence-style                True       True       0.6.0    Yes
   pml100  disallowed-html                 False      False      0.6.0    No
   pml101  list-anchored-indent            False      False      0.6.0    No
-  pml102  disallow-lazy-list-indentation  False      False      0.5.0    No  
+  pml102  disallow-lazy-list-indentation  False      False      0.5.0    No
 """,
     )
 
@@ -1353,7 +1353,7 @@ def test_markdown_with_plugins_list_only_all(scanner_default: MarkdownScanner) -
   md010   no-hard-tabs                    True       True       0.6.1    Yes
   md011   no-reversed-links               True       True       0.5.1    No
   md012   no-multiple-blanks              True       True       0.7.0    Yes
-  md013   line-length                     True       True       0.6.1    No
+  md013   line-length                     True       True       0.6.2    No
   md014   commands-show-output            True       True       0.5.0    No
   md018   no-missing-space-atx            True       True       0.5.1    No
   md019   no-multiple-space-atx           True       True       0.5.1    Yes
@@ -1437,7 +1437,7 @@ def test_markdown_with_plugins_list_after_command_line_disable_all_rules(
   md010   no-hard-tabs                    True       False      0.6.1    Yes
   md011   no-reversed-links               True       False      0.5.1    No
   md012   no-multiple-blanks              True       False      0.7.0    Yes
-  md013   line-length                     True       False      0.6.1    No
+  md013   line-length                     True       False      0.6.2    No
   md014   commands-show-output            True       False      0.5.0    No
   md018   no-missing-space-atx            True       False      0.5.1    No
   md019   no-multiple-space-atx           True       False      0.5.1    Yes
@@ -1525,7 +1525,7 @@ def test_markdown_with_plugins_list_after_configuration_disable_all_rules(
   md010   no-hard-tabs                    True       False      0.6.1    Yes
   md011   no-reversed-links               True       False      0.5.1    No
   md012   no-multiple-blanks              True       False      0.7.0    Yes
-  md013   line-length                     True       False      0.6.1    No
+  md013   line-length                     True       False      0.6.2    No
   md014   commands-show-output            True       False      0.5.0    No
   md018   no-missing-space-atx            True       False      0.5.1    No
   md019   no-multiple-space-atx           True       False      0.5.1    Yes
@@ -1615,7 +1615,7 @@ def test_markdown_with_plugins_list_after_command_line_disable_all_rules_and_ena
   md010   no-hard-tabs                    True       True       0.6.1    Yes
   md011   no-reversed-links               True       False      0.5.1    No
   md012   no-multiple-blanks              True       False      0.7.0    Yes
-  md013   line-length                     True       False      0.6.1    No
+  md013   line-length                     True       False      0.6.2    No
   md014   commands-show-output            True       False      0.5.0    No
   md018   no-missing-space-atx            True       False      0.5.1    No
   md019   no-multiple-space-atx           True       False      0.5.1    Yes


### PR DESCRIPTION
## Summary by Sourcery

Add configurable handling of line-length rule MD013 for markdown tables and document it.

Enhancements:
- Extend MD013 configuration with `tables` and `table_line_length` options and include them in the rule's queryable config.
- Apply table-specific line-length limits when processing table header and row tokens, respecting the `tables` toggle.

Documentation:
- Document the new `tables` and `table_line_length` options for MD013 in the changelog, including their association with issue 1609 and clarifying the earlier table-token fix for issue 1604.

Tests:
- Add regression tests covering MD013 behavior when table line length is within limits, exceeds table-specific limits, and when table checking is enabled or disabled.