### PR TITLE
Issue 1596

### DIFF
--- a/newdocs/requirements.txt
+++ b/newdocs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocstrings==0.29.1
+mkdocstrings==1.0.4
 mkdocstrings-python==1.16.10
-mkdocs-material==9.7.1
-pymdown-extensions==10.20.1
+mkdocs-material==9.7.6
+pymdown-extensions==10.21.3

--- a/newdocs/src/user-guide.md
+++ b/newdocs/src/user-guide.md
@@ -1608,10 +1608,12 @@ exit code:
 
 - Use `default` if you want CI or scripts to fail when:
     - no files were scanned,
+    - asked to fix files with bad configuration,
     - Rule Failures were reported, or
     - files were fixed.
 
 - Use `minimal` if you only want CI to fail for:
+    - invalid actions requested based on current configuration
     - invalid command-line usage, or
     - internal application errors.
 
@@ -1626,6 +1628,8 @@ PyMarkdown first classifies each run into one of these outcome categories:
 - `SUCCESS` – everything looks good, no errors.
 - `NO_FILES_TO_SCAN` – the paths provided produced zero files to scan.
 - `COMMAND_LINE_ERROR` – at least one command-line argument was not valid.
+- `FIXED_NO_PLUGINS` - no files were fixed due to no plugins with `fix mode` being
+  enabled
 - `FIXED_AT_LEAST_ONE_FILE` – at least one file was fixed, changing its content.
 - `SCAN_TRIGGERED_AT_LEAST_ONCE` – at least one failure was triggered.
 - `SYSTEM_ERROR` – an application error occurred, possibly stopping the run early.

--- a/publish/pylint_suppression.json
+++ b/publish/pylint_suppression.json
@@ -96,7 +96,7 @@
         },
         "pymarkdown/file_scan_helper.py": {
             "too-many-instance-attributes": 1,
-            "too-many-arguments": 12,
+            "too-many-arguments": 13,
             "too-many-locals": 5
         },
         "pymarkdown/general/__init__.py": {},
@@ -534,7 +534,7 @@
     "disables-by-name": {
         "too-many-instance-attributes": 30,
         "too-many-public-methods": 5,
-        "too-many-arguments": 278,
+        "too-many-arguments": 279,
         "too-few-public-methods": 39,
         "too-many-locals": 55,
         "chained-comparison": 3,

--- a/pymarkdown/file_scan_helper.py
+++ b/pymarkdown/file_scan_helper.py
@@ -79,7 +79,7 @@ class FileScanHelper:
         use_standard_in: bool,
         files_to_scan: List[str],
         string_to_scan: Optional[str],
-    ) -> Tuple[bool, bool]:
+    ) -> Tuple[bool, bool, bool]:
         """
         Process the specified files to scan, or the string to scan.
         """
@@ -99,6 +99,7 @@ class FileScanHelper:
             self.__process_per_file_ignores()
 
             POGGER.debug("Scanning from: $", files_to_scan)
+            is_first_file = True
             for next_file in files_to_scan:
                 per_file_disabled_identifiers = (
                     self.__check_file_name_against_per_file_disabled_identifiers(
@@ -106,24 +107,56 @@ class FileScanHelper:
                     )
                 )
                 if in_fix_mode:
-                    did_fix_file, did_succeed = self.__fix_specific_file(
-                        next_file,
-                        next_file,
-                        args.x_fix_debug,
-                        args.x_fix_file_debug,
-                        args.x_fix_no_rescan_log,
-                        per_file_disabled_identifiers,
+                    did_succeed, did_fix_any_file, did_attempt_at_least_one_fix = (
+                        self.__fix_specific_file(
+                            is_first_file,
+                            next_file,
+                            args,
+                            per_file_disabled_identifiers,
+                            did_fix_any_file,
+                        )
                     )
-                    if did_fix_file:
-                        self.__presentation.print_fix_message(next_file)
-                        did_fix_any_file = True
+                    if did_attempt_at_least_one_fix:
+                        return False, False, True
                 else:
                     did_succeed = self.__scan_specific_file(
                         next_file, next_file, per_file_disabled_identifiers
                     )
+                is_first_file = False
                 if not did_succeed:
                     did_fail_any_file = True
-        return did_fix_any_file, did_fail_any_file
+        return did_fix_any_file, did_fail_any_file, False
+
+    # pylint: disable=too-many-arguments
+    def __fix_specific_file(
+        self,
+        is_first_file: bool,
+        next_file: str,
+        args: argparse.Namespace,
+        per_file_disabled_identifiers: Set[str],
+        did_fix_any_file: bool,
+    ) -> Tuple[bool, bool, bool]:
+        did_fix_file, did_succeed, did_attempt_at_least_one_fix = (
+            self.__fix_specific_file_with_error_handling(
+                next_file,
+                next_file,
+                args.x_fix_debug,
+                args.x_fix_file_debug,
+                args.x_fix_no_rescan_log,
+                per_file_disabled_identifiers,
+            )
+        )
+        if is_first_file and not did_attempt_at_least_one_fix:
+            self.__presentation.print_system_error(
+                "Cannot fix files: No rule plugins are enabled have fix mode support."
+            )
+            return False, False, True
+        if did_fix_file:
+            self.__presentation.print_fix_message(next_file)
+            did_fix_any_file = True
+        return did_succeed, did_fix_any_file, False
+
+    # pylint: enable=too-many-arguments
 
     def __check_file_name_against_per_file_disabled_identifiers(
         self, next_file_name: str
@@ -274,7 +307,7 @@ class FileScanHelper:
     # pylint: enable=too-many-arguments
 
     # pylint: disable=too-many-arguments
-    def __fix_specific_file(
+    def __fix_specific_file_with_error_handling(
         self,
         next_file: str,
         next_file_name: str,
@@ -282,14 +315,15 @@ class FileScanHelper:
         fix_file_debug: bool,
         fix_nolog_rescan: bool,
         per_file_disabled_identifiers: Optional[Set[str]],
-    ) -> Tuple[bool, bool]:
+    ) -> Tuple[bool, bool, bool]:
         did_fix_file = False
+        did_attempt_at_least_one_fix = False
         did_succeed = False
         try:
             try:
                 POGGER.info("Starting file to fix '$'.", next_file_name)
 
-                did_fix_file = self.__process_file_fix(
+                did_fix_file, did_attempt_at_least_one_fix = self.__process_file_fix(
                     next_file,
                     next_file_name,
                     fix_debug,
@@ -309,7 +343,7 @@ class FileScanHelper:
             if not self.__continue_on_error:
                 raise
             self.__handle_scan_error(next_file, this_exception, allow_shortcut=True)
-        return did_fix_file, did_succeed
+        return did_fix_file, did_succeed, did_attempt_at_least_one_fix
 
     # pylint: enable=too-many-arguments
 
@@ -527,7 +561,7 @@ class FileScanHelper:
         fix_file_debug: bool,
         fix_nolog_rescan: bool,
         per_file_disabled_identifiers: Optional[Set[str]],
-    ) -> bool:
+    ) -> Tuple[bool, bool]:
         enabled_plugins_with_fixes = filter(
             lambda x: x.plugin_supports_fix, self.__plugins.enabled_plugins
         )
@@ -552,9 +586,10 @@ class FileScanHelper:
                 level_list = []
                 plugins_by_fix_level[pair_fix_level] = level_list
             level_list.append(pair_plugin_id)
-        minimum_fix_level = min(plugins_by_fix_level.keys())
         did_anything_get_fixed = False
-        keep_processing = True
+        did_attempt_at_least_one_fix = len(plugins_by_fix_level) != 0
+        keep_processing = did_attempt_at_least_one_fix
+        minimum_fix_level = min(plugins_by_fix_level.keys()) if keep_processing else -1
 
         while keep_processing:
             (
@@ -576,7 +611,7 @@ class FileScanHelper:
                 did_anything_get_fixed or did_anything_get_fixed_this_time
             )
 
-        return did_anything_get_fixed
+        return did_anything_get_fixed, did_attempt_at_least_one_fix
 
     # pylint: enable=too-many-arguments, too-many-locals
 

--- a/pymarkdown/main.py
+++ b/pymarkdown/main.py
@@ -391,10 +391,14 @@ class PyMarkdownLint:
             self.__handle_error,
             self.__properties,
         )
-        did_fix_any_files, did_fail_any_file = fsh.process_files_to_scan(
-            args, use_standard_in, files_to_scan, self.__string_to_scan
+        did_fix_any_files, did_fail_any_file, no_plugins_active_for_fix = (
+            fsh.process_files_to_scan(
+                args, use_standard_in, files_to_scan, self.__string_to_scan
+            )
         )
-        if did_fail_any_file:
+        if no_plugins_active_for_fix:
+            scan_result = ApplicationResult.FIXED_NO_PLUGINS
+        elif did_fail_any_file:
             scan_result = ApplicationResult.SYSTEM_ERROR
         elif did_fix_any_files:
             scan_result = ApplicationResult.FIXED_AT_LEAST_ONE_FILE

--- a/pymarkdown/return_code_helper.py
+++ b/pymarkdown/return_code_helper.py
@@ -24,6 +24,7 @@ class ApplicationResult(Enum):
     FIXED_AT_LEAST_ONE_FILE = 3
     SCAN_TRIGGERED_AT_LEAST_ONCE = 4
     SYSTEM_ERROR = 5
+    FIXED_NO_PLUGINS = 6
 
 
 class SchemeDefinition(ABC):
@@ -59,6 +60,7 @@ class ExplicitScheme(SchemeDefinition):
             ApplicationResult.FIXED_AT_LEAST_ONE_FILE: 3,
             ApplicationResult.SCAN_TRIGGERED_AT_LEAST_ONCE: 4,
             ApplicationResult.SYSTEM_ERROR: 5,
+            ApplicationResult.FIXED_NO_PLUGINS: 6,
         }
 
 
@@ -76,6 +78,7 @@ class DefaultScheme(SchemeDefinition):
             ApplicationResult.FIXED_AT_LEAST_ONE_FILE: 3,
             ApplicationResult.SCAN_TRIGGERED_AT_LEAST_ONCE: 1,
             ApplicationResult.SYSTEM_ERROR: 1,
+            ApplicationResult.FIXED_NO_PLUGINS: 6,
         }
 
 
@@ -93,6 +96,7 @@ class MinimalScheme(SchemeDefinition):
             ApplicationResult.FIXED_AT_LEAST_ONE_FILE: 0,
             ApplicationResult.SCAN_TRIGGERED_AT_LEAST_ONCE: 0,
             ApplicationResult.SYSTEM_ERROR: 1,
+            ApplicationResult.FIXED_NO_PLUGINS: 1,
         }
 
 

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -2542,3 +2542,272 @@ Traceback (most recent call last):
             expected_return_code,
             additional_error=["raise BadPluginFixError( "],
         )
+
+
+def test_markdown_plugins_no_failures_plugins_active_scan(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path("end_with_blank_line.md")
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "scan",
+            temp_source_path,
+        ]
+
+        expected_return_code = 0
+        expected_output = ""
+        expected_error = ""
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_no_failures_no_plugins_active_scan(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path("end_with_blank_line.md")
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "--set",
+            "plugins.selectively_enable_rules=$!true",
+            "scan",
+            temp_source_path,
+        ]
+
+        expected_return_code = 0
+        expected_output = ""
+        expected_error = ""
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_no_failures_plugins_active_fix(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path("end_with_blank_line.md")
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "fix",
+            temp_source_path,
+        ]
+
+        expected_return_code = 0
+        expected_output = ""
+        expected_error = ""
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_no_failures_no_plugins_active_fix(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path("end_with_blank_line.md")
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "--set",
+            "plugins.selectively_enable_rules=$!true",
+            "--stack-trace",
+            "fix",
+            temp_source_path,
+        ]
+
+        expected_return_code = 6
+        expected_output = ""
+        expected_error = (
+            "Cannot fix files: No rule plugins are enabled have fix mode support."
+        )
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_failures_plugins_active_scan(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path(
+        "improper_atx_heading_incrementing.md", "md001"
+    )
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "scan",
+            temp_source_path,
+        ]
+
+        expected_return_code = 1
+        expected_output = f"{temp_source_path}:3:1: MD001: Heading levels should only increment by one level at a time. [Expected: h2; Actual: h3] (heading-increment,header-increment)"
+        expected_error = ""
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_failures_no_plugins_active_scan(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path(
+        "improper_atx_heading_incrementing.md", "md001"
+    )
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "--set",
+            "plugins.selectively_enable_rules=$!true",
+            "scan",
+            temp_source_path,
+        ]
+
+        expected_return_code = 0
+        expected_output = ""
+        expected_error = ""
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_failures_plugins_active_fix(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path(
+        "improper_atx_heading_incrementing.md", "md001"
+    )
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "fix",
+            temp_source_path,
+        ]
+
+        expected_return_code = 3
+        expected_output = f"Fixed: {temp_source_path}"
+        expected_error = ""
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )
+
+
+def test_markdown_plugins_failures_no_plugins_active_fix(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the rule does trigger with a document with
+    only Atx Headings, that when they increase, only increase by 2.
+    """
+
+    # Arrange
+    source_path, _ = __generate_source_path(
+        "improper_atx_heading_incrementing.md", "md001"
+    )
+    with copy_to_temp_file(source_path) as temp_source_path:
+        supplied_arguments = [
+            "--set",
+            "plugins.selectively_enable_rules=$!true",
+            "fix",
+            temp_source_path,
+        ]
+
+        expected_return_code = 6
+        expected_output = ""
+        expected_error = (
+            "Cannot fix files: No rule plugins are enabled have fix mode support."
+        )
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(
+            expected_output,
+            expected_error,
+            expected_return_code,
+        )


### PR DESCRIPTION
## Summary by Sourcery

Handle fix-mode runs when no plugins with fix support are enabled and document the new outcome and return codes.

Bug Fixes:
- Ensure fix runs with no enabled fix-capable plugins report a specific error and exit code instead of behaving like a normal fix/scan run.

Enhancements:
- Extend file scanning and fixing flow to detect when no plugins support fix mode and surface a dedicated FIXED_NO_PLUGINS application result.
- Refine fix-processing logic to track whether any fix-capable plugins were present before attempting fixes.

Documentation:
- Update user guide to describe the new FIXED_NO_PLUGINS outcome and how it affects exit-code schemes.
- Refresh docs build dependencies to newer mkdocs, mkdocstrings, and pymdown-extensions versions.

Tests:
- Add regression tests covering scan and fix behavior with plugins enabled/disabled, including the new no-fix-plugins scenario.