### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/771

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,11 +116,11 @@ jobs:
             ./report/coverage.xml
             ./report/coverage
 
-      - name: Import Codecov PGP key
-        if: ${{ matrix.python == env.default-python-version && matrix.platform == env.default-platform }}
-        run: |
-          curl -Os https://keybase.io/codecovsecurity/pgp_keys.asc
-          gpg --no-default-keyring --keyring trustedkeys.gpg --import pgp_keys.asc
+      # - name: Import Codecov PGP key
+      #   if: ${{ matrix.python == env.default-python-version && matrix.platform == env.default-platform }}
+      #   run: |
+      #     curl -Os https://keybase.io/codecovsecurity/pgp_keys.asc
+      #     gpg --no-default-keyring --keyring trustedkeys.gpg --import pgp_keys.asc
 
       - name: Report Coverage
         uses: codecov/codecov-action@v6
@@ -130,7 +130,7 @@ jobs:
         with:
           files: ./report/coverage.xml
           name: ${{ matrix.python }} - ${{ matrix.platform }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   lint:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./report/coverage.xml
+          files: ./report/coverage.xml
           name: ${{ matrix.python }} - ${{ matrix.platform }}
           fail_ci_if_error: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   project-name: pymarkdown
   default-python-version: 3.13
   default-pipenv-version: 2025.0.3
-  default-platform: windows-latest
+  default-platform: ubuntu-latest
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,7 @@ jobs:
             ./report/coverage
 
       - name: Import Codecov PGP key
+        if: ${{ matrix.python == env.default-python-version && matrix.platform == env.default-platform }}
         run: |
           curl -Os https://keybase.io/codecovsecurity/pgp_keys.asc
           gpg --no-default-keyring --keyring trustedkeys.gpg --import pgp_keys.asc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,11 @@ jobs:
             ./report/coverage.xml
             ./report/coverage
 
+      - name: Import Codecov PGP key
+        run: |
+          curl -Os https://keybase.io/codecovsecurity/pgp_keys.asc
+          gpg --no-default-keyring --keyring trustedkeys.gpg --import pgp_keys.asc
+
       - name: Report Coverage
         uses: codecov/codecov-action@v6
         if: ${{ matrix.python == env.default-python-version && matrix.platform == env.default-platform }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,20 +141,27 @@ repos:
         -   line-length,no-duplicate-heading,no-space-in-emphasis,no-space-in-code
         -   scan
         -   README.md
--   repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.37
+-   repo: local
     hooks:
-    -   id: pymarkdown
-        name: "Scan:   PyMarkdown (New Documentation)"
+    -   id: x1
+        name: "Scan:   PyMarkdown (New Documentation)(local)"
+        language: system
+        entry: ./run.sh -- --config newdocs/clean.json scan -r --exclude "draft-*.md" ./newdocs/src
         pass_filenames: false
-        args:
-        -   --config
-        -   newdocs/clean.json
-        -   scan
-        -   "-r"
-        -   --exclude
-        -   "draft-*.md"
-        -   ./newdocs/src
+# -   repo: https://github.com/jackdewinter/pymarkdown
+#     rev: v0.9.37
+#     hooks:
+#     -   id: pymarkdown
+#         name: "Scan:   PyMarkdown (New Documentation)"
+#         pass_filenames: false
+#         args:
+#         -   --config
+#         -   newdocs/clean.json
+#         -   scan
+#         -   "-r"
+#         -   --exclude
+#         -   "draft-*.md"
+#         -   ./newdocs/src
 -   repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,15 +143,15 @@ repos:
         -   README.md
 -   repo: local
     hooks:
-    -   id: x1
+    -   id: pymarkdown-new
         name: "Scan:   PyMarkdown (New Documentation)(local)"
         language: system
-        entry: ./run.sh -- --config newdocs/clean.json scan -r --exclude "draft-*.md" ./newdocs/src
+        entry: pipenv run python "main.py" --config newdocs/clean.json scan -r --exclude "draft-*.md" ./newdocs/src
         pass_filenames: false
 # -   repo: https://github.com/jackdewinter/pymarkdown
 #     rev: v0.9.37
 #     hooks:
-#     -   id: pymarkdown
+#     -   id: pymarkdown-new
 #         name: "Scan:   PyMarkdown (New Documentation)"
 #         pass_filenames: false
 #         args:

--- a/newdocs/clean.json
+++ b/newdocs/clean.json
@@ -2,7 +2,8 @@
     "plugins": {
         "line-length": {
             "enabled": true,
-            "code_block_line_length" : 160
+            "code_block_line_length" : 160,
+            "tables" : false
         },
         "ul-indent" : {
             "enabled": false
@@ -16,6 +17,9 @@
             "enabled" : true
         },
         "linter-pragmas": {
+            "enabled" : true
+        },
+        "markdown-tables": {
             "enabled" : true
         }
     }

--- a/newdocs/src/advanced_configuration.md
+++ b/newdocs/src/advanced_configuration.md
@@ -295,7 +295,6 @@ the table links to more detailed documentation in the User's Guide or elsewhere.
 These items directly affect the collection of configuration values and how they
 are interpreted.
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- |-- |
 | [(see Configuration File Types)](#configuration-file-types) | `--config {file}`           | String    | Path to the configuration file to use. |
@@ -309,7 +308,6 @@ column to jump to the detailed explanations.
 
 These items affect the logging for PyMarkdown.
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- |-- |
 | `log.file`        | [--log-file](./user-guide.md#-log-level-with-log-file-logging) | String  | Destination file for log messages. |
@@ -369,7 +367,6 @@ see any errors that occur during initialization.
 
 These items configure PyMarkdown's system‑level behavior:
 
-<!-- pyml disable-num-lines 3 line-length-->
 | Key | Command Line | Type | Description |
 | --- | --- | --- | --- |
 | `system.exclude_path` | [`--exclude`](./user-guide.md#-e-exclude-path_exclusions) | String | Comma separated list or native list of relative glob paths to exclude. |
@@ -436,7 +433,6 @@ request).
 These items show the various ways of enabling and disabling Rule Plugins on a global
 level:
 
-<!-- pyml disable-num-lines 6 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- |-- |
 | *special* | [--enable-rules,-e](./user-guide.md#enabling-and-disabling-rule-plugins)   | String    | Comma separated list of Rule Plugins to enable. |
@@ -447,7 +443,6 @@ level:
 This item points to the Development documentation with instructions for creating
 your own plugins:
 
-<!-- pyml disable-num-lines 3 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- | -- |
 | [`plugins.additional_paths`](./development.md) | --add-plugin | String or String List | Path to a plugin containing a new Rule Plugins to load. |
@@ -455,7 +450,6 @@ your own plugins:
 These items give examples on how specific configuration items can be applied to
 Rule Plugins:
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- |-- |
 | [`plugins.{id}.enabled`](#specific-plugin-settings) | -- | Boolean | Specify whether the Rule Plugin is enabled. |
@@ -750,7 +744,6 @@ details.
 
 This item shows how to enable specific extensions:
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- |-- |
 | *special* | [--enable-extensions](./user-guide.md#enabling-extensions)   | String    | Comma separated list of extensions to enable. |
@@ -819,7 +812,6 @@ also links to each extension's page.
 
 These items do not fit nicely into any other category.
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Key | Command Line | Type | Description |
 | -- | -- | -- |-- |
 | -- | [`--continue-on-error`](./user-guide.md#-continue-on-error-error-reporting) | Boolean | Enable PyMarkdown to continue after application errors. |

--- a/newdocs/src/advanced_extensions.md
+++ b/newdocs/src/advanced_extensions.md
@@ -239,7 +239,7 @@ Visit www.commonmark.org/help for more information.
 
 renders as:
 
-<!-- pyml disable-num-lines 5 no-inline-html,line-length -->
+<!-- pyml disable-num-lines 1 no-inline-html,line-length -->
 <p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
 
 #### Disallowed Raw HTML

--- a/newdocs/src/extensions/disallowed-raw-html.md
+++ b/newdocs/src/extensions/disallowed-raw-html.md
@@ -13,7 +13,6 @@
 | --- |
 | `extensions.markdown-disallow-raw-html.` |
 
-<!-- pyml disable-num-lines 4 line-length -->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `False` | Whether the extension is enabled. |

--- a/newdocs/src/extensions/front-matter.md
+++ b/newdocs/src/extensions/front-matter.md
@@ -13,7 +13,6 @@
 | --- |
 | `extensions.front-matter.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `False` | Whether the extension is enabled. |

--- a/newdocs/src/extensions/pragmas.md
+++ b/newdocs/src/extensions/pragmas.md
@@ -153,6 +153,7 @@ command block is referred to as the Pragma command.
 To put this into practical terms, a valid Pragma line matches the following
 regular expression:
 
+<!-- pyml disable-num-lines 3 no-reversed-links-->
 ```regex
 ^<!--[\t\s]*pyml\s(.*)[\t\s]*-->[\t\s]*$
 ```
@@ -335,7 +336,7 @@ Consider this example:
 <!-- pyml disable MD019,line-length-->
 ##  Header with double spaces
 
-This is a simple document with a table, which is not yet supported.
+This is a simple document with a table with many columns.
 
 <!-- pyml disable line-length-->
 | Column 1  | Column 2  | Column 3  | Column 4  | Column 5  | Column 6  | Column 7  |

--- a/newdocs/src/plugins/rule_md001.md
+++ b/newdocs/src/plugins/rule_md001.md
@@ -114,7 +114,6 @@ The heading count (number of `#` characters) is adjusted to match what is expect
 | `plugins.heading-increment.` |
 | `plugins.header-increment.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md002.md
+++ b/newdocs/src/plugins/rule_md002.md
@@ -79,7 +79,6 @@ The reason for not being able to auto-fix this rule is its deprecation in favor 
 | `plugins.first-heading-h1.` |
 | `plugins.first-header-h1.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `False` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md003.md
+++ b/newdocs/src/plugins/rule_md003.md
@@ -91,7 +91,6 @@ release.
 | `plugins.heading-style.` |
 | `plugins.header-style.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
@@ -100,7 +99,6 @@ release.
 
 Valid heading styles:
 
-<!-- pyml disable-num-lines 8 line-length-->
 | Style | Description |
 | -- | -- |
 | `consistent` | The first heading in the document specifies the style for the rest of the document. |

--- a/newdocs/src/plugins/rule_md004.md
+++ b/newdocs/src/plugins/rule_md004.md
@@ -97,7 +97,6 @@ list start.
 | `plugins.md004.` |
 | `plugins.ul-style.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
@@ -105,7 +104,6 @@ list start.
 
 Valid heading styles:
 
-<!-- pyml disable-num-lines 7 line-length-->
 | Style | Description |
 | -- | -- |
 | `consistent` | The first Unordered List Start in the document specifies the style for the rest of the document. |

--- a/newdocs/src/plugins/rule_md007.md
+++ b/newdocs/src/plugins/rule_md007.md
@@ -151,7 +151,6 @@ so on.
 | `plugins.md007.` |
 | `plugins.ul-indent.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md009.md
+++ b/newdocs/src/plugins/rule_md009.md
@@ -89,7 +89,6 @@ whitespace characters at the end of that line.
 | `plugins.md009.` |
 | `plugins.no-trailing-spaces.` |
 
-<!-- pyml disable-num-lines 6 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md010.md
+++ b/newdocs/src/plugins/rule_md010.md
@@ -60,7 +60,6 @@ specification at the above link.
 | `plugins.md010.` |
 | `plugins.no-hard-tabs.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md011.md
+++ b/newdocs/src/plugins/rule_md011.md
@@ -27,6 +27,7 @@ This rule triggers when any non-code block, non-HTML block line
 contains an Inline Link that appears to have the `[]` characters and
 the `()` characters transposed:
 
+<!-- pyml disable-num-lines 3 no-reversed-links -->
 ```Markdown
 This link (is)[/transposed].
 ```

--- a/newdocs/src/plugins/rule_md012.md
+++ b/newdocs/src/plugins/rule_md012.md
@@ -61,7 +61,6 @@ release.
 | `plugins.md012.` |
 | `plugins.no-multiple-blanks.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md013.md
+++ b/newdocs/src/plugins/rule_md013.md
@@ -87,7 +87,6 @@ release.
 | `plugins.md013.` |
 | `plugins.line-length.` |
 
-<!-- pyml disable-num-lines 12 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md022.md
+++ b/newdocs/src/plugins/rule_md022.md
@@ -68,7 +68,6 @@ release.
 | `plugins.blanks-around-headings.` |
 | `plugins.blanks-around-headers.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md024.md
+++ b/newdocs/src/plugins/rule_md024.md
@@ -107,7 +107,6 @@ and made sense within the scope of the document.
 | `plugins.no-duplicate-heading.` |
 | `plugins.no-duplicate-header.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md025.md
+++ b/newdocs/src/plugins/rule_md025.md
@@ -107,7 +107,6 @@ any possible fixes for this rule.
 | `plugins.single-title.` |
 | `plugins.single-h1.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md026.md
+++ b/newdocs/src/plugins/rule_md026.md
@@ -69,7 +69,6 @@ properly handles the punctuation is not possible.
 | `plugins.md026.` |
 | `plugins.no-trailing-punctuation.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md029.md
+++ b/newdocs/src/plugins/rule_md029.md
@@ -139,7 +139,6 @@ changing that second item's list start to `2`.
 | `plugins.md029.` |
 | `plugins.ol-prefix.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
@@ -148,7 +147,6 @@ changing that second item's list start to `2`.
 
 Valid heading styles:
 
-<!-- pyml disable-num-lines 6 line-length-->
 | Style | Description |
 | -- | -- |
 | `one_or_ordered` | Either of the `one` or `ordered` styles below. |

--- a/newdocs/src/plugins/rule_md030.md
+++ b/newdocs/src/plugins/rule_md030.md
@@ -76,7 +76,6 @@ list start sequences will be set to have 1 space before the text.
 | `plugins.md030.` |
 | `plugins.list-marker-space.` |
 
-<!-- pyml disable-num-lines 7 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md031.md
+++ b/newdocs/src/plugins/rule_md031.md
@@ -98,7 +98,6 @@ release.
 | `plugins.md031.` |
 | `plugins.blanks-around-fences.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md033.md
+++ b/newdocs/src/plugins/rule_md033.md
@@ -85,7 +85,6 @@ compelling argument to provide a fix for this rule.
 | `plugins.md033.` |
 | `plugins.no-inline-html.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md035.md
+++ b/newdocs/src/plugins/rule_md035.md
@@ -73,7 +73,6 @@ document sets the thematic break text used throughout the document.
 | `plugins.md035.` |
 | `plugins.hr-style.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md036.md
+++ b/newdocs/src/plugins/rule_md036.md
@@ -74,7 +74,6 @@ that are created with emphasis, it does not attempt to fix them.
 | `plugins.no-emphasis-as-heading.` |
 | `plugins.no-emphasis-as-header.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md041.md
+++ b/newdocs/src/plugins/rule_md041.md
@@ -164,7 +164,6 @@ what text should be in that heading.
 | `plugins.first-line-heading.` |
 | `plugins.first-line-h1.` |
 
-<!-- pyml disable-num-lines 6 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md043.md
+++ b/newdocs/src/plugins/rule_md043.md
@@ -102,7 +102,6 @@ headings, determining the "proper" algorithm quickly becomes problematic.
 | `plugins.required-headings.` |
 | `plugins.required-headers.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md044.md
+++ b/newdocs/src/plugins/rule_md044.md
@@ -93,7 +93,6 @@ configuration item.
 | `plugins.md044.` |
 | `plugins.proper-names.` |
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/plugins/rule_md046.md
+++ b/newdocs/src/plugins/rule_md046.md
@@ -85,7 +85,6 @@ translation from indented-to-fenced code block have their issues.
 | `plugins.md046.` |
 | `plugins.code-block-style.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
@@ -93,7 +92,6 @@ translation from indented-to-fenced code block have their issues.
 
 Valid heading styles:
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Style | Description |
 | -- | -- |
 | `consistent` | The first heading in the document specifies the style for the rest of the document. |

--- a/newdocs/src/plugins/rule_md048.md
+++ b/newdocs/src/plugins/rule_md048.md
@@ -73,7 +73,6 @@ with the selected style type.
 | `plugins.md048.` |
 | `plugins.code-fence-style.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
@@ -81,7 +80,6 @@ with the selected style type.
 
 Valid heading styles:
 
-<!-- pyml disable-num-lines 5 line-length-->
 | Style | Description |
 | -- | -- |
 | `consistent` | The first heading in the document specifies the style for the rest of the document. |

--- a/newdocs/src/plugins/rule_pml100.md
+++ b/newdocs/src/plugins/rule_pml100.md
@@ -81,7 +81,6 @@ The fix for this rule is currently in review.
 | `plugins.pml101.` |
 | `plugins.disallowed-html.` |
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Value Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |

--- a/newdocs/src/quick-starts/fixing.md
+++ b/newdocs/src/quick-starts/fixing.md
@@ -142,8 +142,6 @@ automatically.
 The full list is also available in our [User Guide](../user-guide.md#rule-plugins-with-autofix)
 for easy reference.
 
-<!-- pyml disable line-length-->
-
 | Rule ID & Link | Human-Readable Identifier | Short Description |
 | -- | -- | -- |
 | [MD001](../plugins/rule_md001.md#fix-description) | `heading-increment`, `header-increment` | Heading levels should only increment by one level at a time. |
@@ -167,8 +165,6 @@ for easy reference.
 | [MD046](../plugins/rule_md046.md#fix-description) | `code-block-style` | Code block style. |
 | [MD047](../plugins/rule_md047.md#fix-description) | `single-trailing-newline` | Each file should end with a single newline character. |
 | [MD048](../plugins/rule_md048.md#fix-description) | `code-fence-style` | Code fence style should be consistent throughout the document. |
-
-<!-- pyml enable line-length-->
 
 This list may evolve as new Rule Plugins are added or existing Rule Plugins gain
 or lose **autofix**

--- a/newdocs/src/user-guide.md
+++ b/newdocs/src/user-guide.md
@@ -910,8 +910,6 @@ Before relying on
 These steps help you avoid unexpected changes in fix behavior when you move between
 PyMarkdown versions.
 
-<!-- pyml disable line-length-->
-
 | Rule ID & Link | Human-Readable Identifier | Short Description |
 | -- | -- | -- |
 | [MD001](./plugins/rule_md001.md#fix-description) | `heading-increment`, `header-increment` | Heading levels should only increment by one level at a time. |
@@ -935,8 +933,6 @@ PyMarkdown versions.
 | [MD046](./plugins/rule_md046.md#fix-description) | `code-block-style` | Code block style. |
 | [MD047](./plugins/rule_md047.md#fix-description) | `single-trailing-newline` | Each file should end with a single newline character. |
 | [MD048](./plugins/rule_md048.md#fix-description) | `code-fence-style` | Code fence style should be consistent throughout the document. |
-
-<!-- pyml enable line-length-->
 
 #### Fix Examples
 
@@ -1050,7 +1046,6 @@ the document. These are most useful when:
 
 The five specification extensions are:
 
-<!-- pyml disable-num-lines 7 line-length-->
 | Extension | GFM Link | Description |
 | --- | --- | --- |
 | [Tables](./advanced_extensions.md#markdown-tables) | [GFM](https://github.github.com/gfm/#tables-extension-) | Tables using the \| character. |
@@ -1083,7 +1078,6 @@ In broad terms:
   specific Rule Plugins over selected line ranges, without changing how the Markdown
   itself is parsed.
 
-<!-- pyml disable-num-lines 4 line-length-->
 | Extension | Enabled By Default | Description |
 | --- | --- | --- |
 | [Front-Matter](./extensions/front-matter.md) | No | YAML Front-Matter for files. |
@@ -1293,7 +1287,7 @@ Markdown document, you can disable the corresponding Rule Plugins by id or by al
     ```sh
     # disable by Rule Plugin id
     pymarkdown -d MD012,MD013 scan examples
-    
+
     # or, disable by Rule Plugin aliases:
     pymarkdown -d no-multiple-blanks,line-length scan examples
     ```

--- a/test/test_markdown_extra_issue_1482.py
+++ b/test/test_markdown_extra_issue_1482.py
@@ -4,6 +4,8 @@ Extra tests.
 
 from test.utils import act_and_assert
 
+import pytest
+
 
 def test_extra_issue_1482_x() -> None:
     """
@@ -678,4 +680,102 @@ def test_extra_issue_1482_h() -> None:
         source_markdown,
         expected_gfm,
         expected_tokens,
+    )
+
+
+@pytest.mark.skip
+def test_extra_issue_1482_i() -> None:
+    """
+    https://github.com/jackdewinter/pymarkdown/issues/1482
+    https://github.com/jackdewinter/pymarkdown/issues/1615
+    """
+
+    # Arrange
+    source_markdown = """# Title
+
+> - a
+>   > - b
+>   >   > - c
+>   >   >   > - d
+>   >   >   >   > - e
+"""
+    expected_tokens = [
+        "[atx(1,1):1:0:]",
+        "[text(1,3):Title: ]",
+        "[end-atx::]",
+        "[BLANK(2,1):]",
+        "[block-quote(3,1)::> \n> ]",
+        "[ulist(3,3):-::4:]",
+        "[para(3,5):]",
+        "[text(3,5):a:]",
+        "[end-para:::True]",
+        "[block-quote(4,5)::> \n>   > ]",
+        "[ulist(4,7):-::8:    ]",
+        "[para(4,9):]",
+        "[text(4,9):b:]",
+        "[end-para:::True]",
+        "[block-quote(5,9)::> \n>   > \n> ]",
+        "[ulist(5,11):-::12:        ]",
+        "[para(5,13):]",
+        "[text(5,13):c:]",
+        "[end-para:::True]",
+        "[block-quote(6,13)::> \n>   > \n> \n> ]",
+        "[ulist(6,15):-::16:            ]",
+        "[para(6,17):]",
+        "[text(6,17):d:]",
+        "[end-para:::True]",
+        "[block-quote(7,17)::> ]",
+        "[ulist(7,19):-::20:                ]",
+        "[para(7,21):]",
+        "[text(7,21):e:]",
+        "[end-para:::True]",
+        "[end-ulist:::True]",
+        "[end-block-quote:::True]",
+        "[end-ulist:::True]",
+        "[end-block-quote:::True]",
+        "[end-ulist:::True]",
+        "[end-block-quote:::True]",
+        "[end-ulist:::True]",
+        "[end-block-quote:::True]",
+        "[end-ulist:::True]",
+        "[end-block-quote:::True]",
+        "[BLANK(8,1):]",
+    ]
+    expected_gfm = """<h1>Title</h1>
+<blockquote>
+<ul>
+<li>a
+<blockquote>
+<ul>
+<li>b
+<blockquote>
+<ul>
+<li>c
+<blockquote>
+<ul>
+<li>d
+<blockquote>
+<ul>
+<li>e</li>
+</ul>
+</blockquote>
+</li>
+</ul>
+</blockquote>
+</li>
+</ul>
+</blockquote>
+</li>
+</ul>
+</blockquote>
+</li>
+</ul>
+</blockquote>"""
+
+    # Act & Assert
+    act_and_assert(
+        source_markdown,
+        expected_gfm,
+        expected_tokens,
+        show_debug=False,
     )


### PR DESCRIPTION
## Summary by Sourcery

Update pre-commit configuration for local PyMarkdown documentation scanning and clean up documentation-specific linter directives in the new docs.

Build:
- Switch PyMarkdown documentation scan in pre-commit to use a local system hook invoking run.sh instead of the remote pymarkdown repo hook.

Documentation:
- Remove or narrow broad PyMarkdown linter suppression comments across new documentation, adding targeted disables where necessary and adjusting examples and wording to reflect current behavior.