### PR TITLE
https://github.com/jackdewinter/pymarkdown/issues/979

### DIFF
--- a/pymarkdown/plugins/utils/container_token_manager.py
+++ b/pymarkdown/plugins/utils/container_token_manager.py
@@ -31,6 +31,8 @@ class ContainerTokenManager:
         self.container_token_stack = []
         self.bq_line_index = {}
         self.last_leaf_token = None
+        self.list_adjust_map = {}
+        self.bq_close_map = {}
 
     @classmethod
     def __is_simple_delta(cls, token: MarkdownToken) -> bool:

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -17683,6 +17683,7 @@ another list</li>
         show_debug=False,
     )
 
+
 @pytest.mark.gfm
 def test_extra_999() -> None:
     """

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -17683,7 +17683,6 @@ another list</li>
         show_debug=False,
     )
 
-
 @pytest.mark.gfm
 def test_extra_999() -> None:
     """

--- a/test/utils.py
+++ b/test/utils.py
@@ -283,6 +283,7 @@ def copy_to_temporary_file(source_path: str) -> str:
     Copy an existing markdown file to a temporary markdown file,
     to allow fo fixing the file without destroying the original.
     """
+    source_path  = os.path.abspath(source_path)
     with tempfile.NamedTemporaryFile("wt", delete=False, suffix=".md") as outfile:
         temporary_file = outfile.name
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -283,7 +283,7 @@ def copy_to_temporary_file(source_path: str) -> str:
     Copy an existing markdown file to a temporary markdown file,
     to allow fo fixing the file without destroying the original.
     """
-    source_path  = os.path.abspath(source_path)
+    source_path = os.path.abspath(source_path)
     with tempfile.NamedTemporaryFile("wt", delete=False, suffix=".md") as outfile:
         temporary_file = outfile.name
 


### PR DESCRIPTION
## Summary by Sourcery

Reset additional container token manager state and normalize test input file paths.

Enhancements:
- Ensure container token manager clear() also resets list adjustment and blockquote close tracking maps.
- Normalize source paths to absolute paths when copying markdown files to temporary locations in test utilities.