### PR TITLE
Issue 1625

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 SCRIPT_NAME=$(basename -- "${BASH_SOURCE[0]}")
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 TEMP_FILE=$(mktemp /tmp/"${SCRIPT_NAME}".XXXXXXXXX)
+TEMP_FILE2=$(mktemp /tmp/"${SCRIPT_NAME}".XXXXXXXXX)
 
 SCRIPT_TITLE="Analyzing project cleanliness"
 
@@ -22,6 +23,9 @@ cleanup_function() {
 	# If the temp file was used, get rid of it.
 	if [ -f "${TEMP_FILE}" ]; then
 		rm "${TEMP_FILE}"
+	fi
+	if [ -f "${TEMP_FILE2}" ]; then
+		rm "${TEMP_FILE2}"
 	fi
 
 	# Restore the current directory.
@@ -86,6 +90,7 @@ show_usage() {
 	echo "  -ns,--no-sourcery       Do not run any sourcery checks."
 	echo "  -nu,--no-upgrades       Do not run checks for upgrades."
 	echo "  -nw,--no-workers        Do not use multipel workers when executing tests."
+	echo "  --no-shellcheck       	Do not run any shellcheck checks."
 	echo "  -s,--sourcery-only      Only run sourcery checks and exit."
 	echo "  --perf                  Collect standard performance metrics."
 	echo "  --perf-only             Only collect standard performance metrics."
@@ -107,6 +112,7 @@ parse_command_line() {
 	MYPY_ONLY_MODE=0
 	SOURCERY_ONLY_MODE=0
 	NO_SOURCERY_MODE=0
+	NO_SHELLCHECK_MODE=0
 	NO_UPGRADE_MODE=0
 	FORCE_RESET_MODE=0
 	RESET_PYTHON_VERSION=
@@ -133,6 +139,10 @@ parse_command_line() {
 			;;
 		-ns | --no-sourcery)
 			NO_SOURCERY_MODE=1
+			shift
+			;;
+		--no-shellcheck)
+			NO_SHELLCHECK_MODE=1
 			shift
 			;;
 		-nu | --no-upgrades)
@@ -242,12 +252,19 @@ execute_pre_commit() {
 	PRE_COMMIT_ARGS=()
 	if [[ ${MYPY_ONLY_MODE} -ne 0 ]]; then
 		PRE_COMMIT_ARGS+=("mypy")
+	elif [[ ${NO_SHELLCHECK_MODE} -ne 0 ]]; then
+		if ! pipenv run python utils/remove_precommit_hook_ids.py "${TEMP_FILE}" >"${TEMP_FILE2}" 2>&1; then
+			cat "${TEMP_FILE2}"
+			echo "Pre-commit file is not configured properly. Exitting"
+			exit 1
+		fi
+		PRE_COMMIT_ARGS+=("--config")
+		PRE_COMMIT_ARGS+=("${TEMP_FILE}")
 	fi
 	if [[ ${PUBLISH_MODE} -ne 0 ]]; then
 		PRE_COMMIT_ARGS+=("--all")
 	fi
-	echo ""
-	if ! pipenv run pre-commit run "${PRE_COMMIT_ARGS[@]}"; then
+	if ! pipenv run pre-commit run ${PRE_COMMIT_ARGS[@]}; then
 		complete_process 1 "{Executing pre-commit hooks on Python code failed.}"
 	fi
 	echo ""

--- a/clean.sh
+++ b/clean.sh
@@ -264,7 +264,7 @@ execute_pre_commit() {
 	if [[ ${PUBLISH_MODE} -ne 0 ]]; then
 		PRE_COMMIT_ARGS+=("--all")
 	fi
-	if ! pipenv run pre-commit run ${PRE_COMMIT_ARGS[@]}; then
+	if ! pipenv run pre-commit run "${PRE_COMMIT_ARGS[@]}"; then
 		complete_process 1 "{Executing pre-commit hooks on Python code failed.}"
 	fi
 	echo ""

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -2,12 +2,12 @@
     "projectName": "pymarkdown",
     "reportSource": "Unknown",
     "branchLevel": {
-        "totalMeasured": 5876,
-        "totalCovered": 5876
+        "totalMeasured": 5962,
+        "totalCovered": 5960
     },
     "lineLevel": {
-        "totalMeasured": 23561,
-        "totalCovered": 23561
+        "totalMeasured": 24104,
+        "totalCovered": 24104
     }
 }
 

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -6,8 +6,8 @@
         "totalCovered": 5960
     },
     "lineLevel": {
-        "totalMeasured": 24104,
-        "totalCovered": 24104
+        "totalMeasured": 24107,
+        "totalCovered": 24107
     }
 }
 

--- a/publish/pylint_suppression.json
+++ b/publish/pylint_suppression.json
@@ -441,7 +441,9 @@
         "pymarkdown/tokens/html_block_markdown_token.py": {
             "protected-access": 1
         },
-        "pymarkdown/tokens/html_items.py": {},
+        "pymarkdown/tokens/html_items.py": {
+            "too-few-public-methods": 14
+        },
         "pymarkdown/tokens/image_start_markdown_token.py": {
             "too-many-arguments": 1,
             "protected-access": 1
@@ -570,7 +572,7 @@
         "too-many-instance-attributes": 30,
         "too-many-public-methods": 5,
         "too-many-arguments": 292,
-        "too-few-public-methods": 43,
+        "too-few-public-methods": 57,
         "too-many-locals": 57,
         "chained-comparison": 3,
         "too-many-boolean-expressions": 10,

--- a/publish/pylint_suppression.json
+++ b/publish/pylint_suppression.json
@@ -409,6 +409,7 @@
         "pymarkdown/tokens/html_block_markdown_token.py": {
             "protected-access": 1
         },
+        "pymarkdown/tokens/html_items.py": {},
         "pymarkdown/tokens/image_start_markdown_token.py": {
             "too-many-arguments": 1,
             "protected-access": 1

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1220,7 +1220,7 @@
         },
         {
             "name": "test.rules.test_md013",
-            "totalTests": 45,
+            "totalTests": 49,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1516,7 +1516,7 @@
         },
         {
             "name": "test.rules.test_plugin_manager",
-            "totalTests": 62,
+            "totalTests": 70,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1644,7 +1644,7 @@
         },
         {
             "name": "test.test_markdown_extra",
-            "totalTests": 356,
+            "totalTests": 357,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 2,
@@ -1652,10 +1652,10 @@
         },
         {
             "name": "test.test_markdown_extra_issue_1482",
-            "totalTests": 9,
+            "totalTests": 10,
             "failedTests": 0,
             "errorTests": 0,
-            "skippedTests": 0,
+            "skippedTests": 1,
             "elapsedTimeInMilliseconds": 0
         },
         {

--- a/pymarkdown/extensions/front_matter_markdown_token.py
+++ b/pymarkdown/extensions/front_matter_markdown_token.py
@@ -164,8 +164,9 @@ class FrontMatterMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_front_matter_token(
         output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken, transform_state: TransformState
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
     ) -> str:
         """
         Handle the front matter token.  Note that it does not contribute anything

--- a/pymarkdown/extensions/front_matter_markdown_token.py
+++ b/pymarkdown/extensions/front_matter_markdown_token.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple, cast
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -162,12 +163,14 @@ class FrontMatterMarkdownToken(LeafMarkdownToken):
 
     @staticmethod
     def __handle_front_matter_token(
-        output_html: str, next_token: MarkdownToken, transform_state: TransformState
+        output_html: str,
+        output_parts : List[HtmlItems],
+        next_token: MarkdownToken, transform_state: TransformState
     ) -> str:
         """
         Handle the front matter token.  Note that it does not contribute anything
         at all to the HTML output.
         """
-        _ = (next_token, transform_state)
+        _ = (next_token, transform_state, output_parts)
 
         return output_html

--- a/pymarkdown/extensions/pragma_token.py
+++ b/pymarkdown/extensions/pragma_token.py
@@ -576,7 +576,7 @@ class PragmaToken(MarkdownToken):
     @staticmethod
     def __handle_pragma_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:

--- a/pymarkdown/extensions/pragma_token.py
+++ b/pymarkdown/extensions/pragma_token.py
@@ -22,6 +22,7 @@ from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.my_application_properties_facade import MyApplicationPropertiesFacade
 from pymarkdown.plugin_manager.found_plugin import FoundPlugin
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.markdown_token import MarkdownToken, MarkdownTokenClass
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_markdown.markdown_transform_context import (
@@ -575,9 +576,10 @@ class PragmaToken(MarkdownToken):
     @staticmethod
     def __handle_pragma_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
-        _ = (transform_state, next_token)
+        _ = (transform_state, next_token, output_parts)
 
         return output_html

--- a/pymarkdown/extensions/task_list_items.py
+++ b/pymarkdown/extensions/task_list_items.py
@@ -2,7 +2,7 @@
 Module to provide for a list item that can be check off.
 """
 
-from typing import List, Optional, cast
+from typing import Dict, List, Optional, cast
 
 from pymarkdown.extension_manager.extension_impl import ExtensionDetails
 from pymarkdown.extension_manager.extension_manager_constants import (
@@ -10,7 +10,7 @@ from pymarkdown.extension_manager.extension_manager_constants import (
 )
 from pymarkdown.extension_manager.parser_extension import ParserExtension
 from pymarkdown.my_application_properties_facade import MyApplicationPropertiesFacade
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import HtmlItems, HtmlOpenTagItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -130,14 +130,14 @@ class TaskListToken(InlineMarkdownToken):
         """
         register_handlers(
             TaskListToken,
-            TaskListToken.__handle_pragma_token,
+            TaskListToken.__handle_task_list_token,
             None,
         )
 
     @staticmethod
-    def __handle_pragma_token(
+    def __handle_task_list_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -145,9 +145,22 @@ class TaskListToken(InlineMarkdownToken):
 
         task_list_token = cast(TaskListToken, next_token)
 
+        attributes_map: Dict[str, str] = {}
+        if task_list_token.checked_character != " ":
+            attributes_map["checked"] = ""
+        attributes_map["type"] = "checkbox"
+
+        output_parts.append(HtmlOpenTagItem("input", attributes_map))
+
+        return TaskListToken.__handle_task_list_token_old(output_html, task_list_token)
+
+    @staticmethod
+    def __handle_task_list_token_old(
+        output_html: str, task_list_token: "TaskListToken"
+    ) -> str:
         if task_list_token.checked_character == " ":
             xx = '<input type="checkbox">'
         else:
             xx = '<input checked="" type="checkbox">'
-        output_parts.append(ZuluHtmlItem(xx))
+
         return output_html + xx

--- a/pymarkdown/extensions/task_list_items.py
+++ b/pymarkdown/extensions/task_list_items.py
@@ -2,7 +2,7 @@
 Module to provide for a list item that can be check off.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.extension_manager.extension_impl import ExtensionDetails
 from pymarkdown.extension_manager.extension_manager_constants import (
@@ -10,6 +10,7 @@ from pymarkdown.extension_manager.extension_manager_constants import (
 )
 from pymarkdown.extension_manager.parser_extension import ParserExtension
 from pymarkdown.my_application_properties_facade import MyApplicationPropertiesFacade
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -136,14 +137,17 @@ class TaskListToken(InlineMarkdownToken):
     @staticmethod
     def __handle_pragma_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
         task_list_token = cast(TaskListToken, next_token)
+
         if task_list_token.checked_character == " ":
-            output_html += '<input type="checkbox">'
+            xx = '<input type="checkbox">'
         else:
-            output_html += '<input checked="" type="checkbox">'
-        return output_html
+            xx = '<input checked="" type="checkbox">'
+        output_parts.append(ZuluHtmlItem(xx))
+        return output_html + xx

--- a/pymarkdown/tokens/atx_heading_markdown_token.py
+++ b/pymarkdown/tokens/atx_heading_markdown_token.py
@@ -2,12 +2,13 @@
 Module to provide for an encapsulation of the atx heading element.
 """
 
-from typing import Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import FormatOnlyNewLineHtmlItem, HtmlCloseTagItem, HtmlItems, HtmlStartTagItem, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.setext_heading_markdown_token import SetextHeadingMarkdownToken
@@ -178,6 +179,7 @@ class AtxHeadingMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_atx_heading_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -186,17 +188,22 @@ class AtxHeadingMarkdownToken(LeafMarkdownToken):
             transform_state.actual_token_index - 1
         ]
 
-        token_parts = [output_html]
+        token_parts : List[str]= []
         if (output_html.endswith("</ol>") or output_html.endswith("</ul>")) or (
             previous_token.is_paragraph_end and not transform_state.is_in_loose_list
         ):
             token_parts.append(ParserHelper.newline_character)
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+
         token_parts.extend(["<h", str(atx_token.hash_count), ">"])
+        output_parts.append(HtmlStartTagItem(f"h{atx_token.hash_count}"))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_atx_heading_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -210,6 +217,9 @@ class AtxHeadingMarkdownToken(LeafMarkdownToken):
             transform_state.actual_tokens[fenced_token_index],
         )
 
+        output_parts.append(HtmlCloseTagItem(f"h{fenced_token.hash_count}"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+        
         return "".join(
             [
                 output_html,

--- a/pymarkdown/tokens/atx_heading_markdown_token.py
+++ b/pymarkdown/tokens/atx_heading_markdown_token.py
@@ -8,7 +8,12 @@ from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import FormatOnlyNewLineHtmlItem, HtmlCloseTagItem, HtmlItems, HtmlStartTagItem, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.setext_heading_markdown_token import SetextHeadingMarkdownToken
@@ -179,7 +184,7 @@ class AtxHeadingMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_atx_heading_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -188,22 +193,24 @@ class AtxHeadingMarkdownToken(LeafMarkdownToken):
             transform_state.actual_token_index - 1
         ]
 
-        token_parts : List[str]= []
-        if (output_html.endswith("</ol>") or output_html.endswith("</ul>")) or (
-            previous_token.is_paragraph_end and not transform_state.is_in_loose_list
-        ):
-            token_parts.append(ParserHelper.newline_character)
+        if previous_token.is_paragraph_end and not transform_state.is_in_loose_list:
             output_parts.append(FormatOnlyNewLineHtmlItem())
+        if (
+            output_parts
+            and isinstance(output_parts[-1], HtmlCloseTagItem)
+            and output_parts[-1].get_raw_html_text() in ["</ul>", "</ol>"]
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenTagItem(f"h{atx_token.hash_count}"))
 
-        token_parts.extend(["<h", str(atx_token.hash_count), ">"])
-        output_parts.append(HtmlStartTagItem(f"h{atx_token.hash_count}"))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+        return AtxHeadingMarkdownToken.__handle_start_atx_heading_token_old(
+            output_html, transform_state, atx_token, previous_token
+        )
 
     @staticmethod
     def __handle_end_atx_heading_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -219,7 +226,30 @@ class AtxHeadingMarkdownToken(LeafMarkdownToken):
 
         output_parts.append(HtmlCloseTagItem(f"h{fenced_token.hash_count}"))
         output_parts.append(FormatOnlyNewLineHtmlItem())
-        
+
+        return AtxHeadingMarkdownToken.__handle_end_atx_heading_token_old(
+            output_html, fenced_token
+        )
+
+    @staticmethod
+    def __handle_start_atx_heading_token_old(
+        output_html: str,
+        transform_state: TransformState,
+        atx_token: "AtxHeadingMarkdownToken",
+        previous_token: MarkdownToken,
+    ) -> str:
+        token_parts: List[str] = [output_html]
+        if (output_html.endswith("</ol>") or output_html.endswith("</ul>")) or (
+            previous_token.is_paragraph_end and not transform_state.is_in_loose_list
+        ):
+            token_parts.append(ParserHelper.newline_character)
+        token_parts.extend(["<h", str(atx_token.hash_count), ">"])
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_end_atx_heading_token_old(
+        output_html: str, fenced_token: SetextHeadingMarkdownToken
+    ) -> str:
         return "".join(
             [
                 output_html,

--- a/pymarkdown/tokens/blank_line_markdown_token.py
+++ b/pymarkdown/tokens/blank_line_markdown_token.py
@@ -6,7 +6,7 @@ from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import HtmlBlockNewLineHtmlItem, HtmlItems
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -104,13 +104,24 @@ class BlankLineMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_blank_line_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
         if transform_state.is_in_html_block:
+            output_parts.append(HtmlBlockNewLineHtmlItem())
+
+        return BlankLineMarkdownToken.__handle_blank_line_token_old(
+            output_html, transform_state
+        )
+
+    @staticmethod
+    def __handle_blank_line_token_old(
+        output_html: str,
+        transform_state: TransformState,
+    ) -> str:
+        if transform_state.is_in_html_block:
             output_html = f"{output_html}{ParserHelper.newline_character}"
-            output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         return output_html

--- a/pymarkdown/tokens/blank_line_markdown_token.py
+++ b/pymarkdown/tokens/blank_line_markdown_token.py
@@ -2,10 +2,11 @@
 Module to provide for an encapsulation of the blank line element.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -103,6 +104,7 @@ class BlankLineMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_blank_line_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -110,4 +112,5 @@ class BlankLineMarkdownToken(LeafMarkdownToken):
 
         if transform_state.is_in_html_block:
             output_html = f"{output_html}{ParserHelper.newline_character}"
+            output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         return output_html

--- a/pymarkdown/tokens/block_quote_markdown_token.py
+++ b/pymarkdown/tokens/block_quote_markdown_token.py
@@ -3,7 +3,7 @@ Module to provide for an encapsulation of the block quote element.
 """
 
 import logging
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from typing_extensions import override
 
@@ -11,6 +11,7 @@ from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.tokens.container_markdown_token import ContainerMarkdownToken
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_gfm.transform_to_gfm_list_looseness import (
@@ -205,27 +206,32 @@ class BlockQuoteMarkdownToken(ContainerMarkdownToken):
     @staticmethod
     def __handle_start_block_quote_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        token_parts = [output_html]
+        token_parts : List[str]= []
         if output_html and output_html[-1] != ParserHelper.newline_character:
             token_parts.append(ParserHelper.newline_character)
         transform_state.is_in_loose_list = True
         token_parts.extend(["<blockquote>", ParserHelper.newline_character])
+        
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_block_quote_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        token_parts = [output_html]
+        token_parts : List[str]= []
         if output_html[-1] != ParserHelper.newline_character:
             token_parts.append(ParserHelper.newline_character)
         transform_state.is_in_loose_list = (
@@ -235,6 +241,9 @@ class BlockQuoteMarkdownToken(ContainerMarkdownToken):
             )
         )
         token_parts.extend(["</blockquote>", ParserHelper.newline_character])
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @override

--- a/pymarkdown/tokens/block_quote_markdown_token.py
+++ b/pymarkdown/tokens/block_quote_markdown_token.py
@@ -11,7 +11,13 @@ from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.tokens.container_markdown_token import ContainerMarkdownToken
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlBlockItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_gfm.transform_to_gfm_list_looseness import (
@@ -190,6 +196,14 @@ class BlockQuoteMarkdownToken(ContainerMarkdownToken):
 
         return leading_text
 
+    @override
+    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
+        if field_name == "bleading_spaces" and isinstance(field_value, str):
+            self.__leading_spaces = field_value
+            self.__compose_extra_data_field()
+            return True
+        return super()._modify_token(field_name, field_value)
+
     @staticmethod
     def register_for_html_transform(
         register_handlers: RegisterHtmlTransformHandlersProtocol,
@@ -206,53 +220,75 @@ class BlockQuoteMarkdownToken(ContainerMarkdownToken):
     @staticmethod
     def __handle_start_block_quote_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        token_parts : List[str]= []
-        if output_html and output_html[-1] != ParserHelper.newline_character:
-            token_parts.append(ParserHelper.newline_character)
         transform_state.is_in_loose_list = True
-        token_parts.extend(["<blockquote>", ParserHelper.newline_character])
-        
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+
+        if (
+            output_parts
+            and not isinstance(output_parts[-1], FormatOnlyNewLineHtmlItem)
+            and not (
+                isinstance(output_parts[-1], HtmlBlockItem)
+                and output_parts[-1]
+                .get_raw_html_text()
+                .endswith(ParserHelper.newline_character)
+            )
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenTagItem("blockquote"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return BlockQuoteMarkdownToken.__handle_start_block_quote_token_old(output_html)
 
     @staticmethod
     def __handle_end_block_quote_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        token_parts : List[str]= []
-        if output_html[-1] != ParserHelper.newline_character:
-            token_parts.append(ParserHelper.newline_character)
         transform_state.is_in_loose_list = (
             TransformToGfmListLooseness.reset_list_looseness(
                 transform_state.actual_tokens,
                 transform_state.actual_token_index,
             )
         )
-        token_parts.extend(["</blockquote>", ParserHelper.newline_character])
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        if not isinstance(output_parts[-1], FormatOnlyNewLineHtmlItem) and not (
+            isinstance(output_parts[-1], HtmlBlockItem)
+            and output_parts[-1]
+            .get_raw_html_text()
+            .endswith(ParserHelper.newline_character)
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlCloseTagItem("blockquote"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return BlockQuoteMarkdownToken.__handle_end_block_quote_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_block_quote_token_old(output_html: str) -> str:
+        token_parts: List[str] = []
+        if output_html and output_html[-1] != ParserHelper.newline_character:
+            token_parts.append(ParserHelper.newline_character)
+        token_parts.extend(["<blockquote>", ParserHelper.newline_character])
         token_parts.insert(0, output_html)
         return "".join(token_parts)
 
-    @override
-    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
-        if field_name == "bleading_spaces" and isinstance(field_value, str):
-            self.__leading_spaces = field_value
-            self.__compose_extra_data_field()
-            return True
-        return super()._modify_token(field_name, field_value)
+    @staticmethod
+    def __handle_end_block_quote_token_old(output_html: str) -> str:
+        token_parts: List[str] = []
+        if output_html[-1] != ParserHelper.newline_character:
+            token_parts.append(ParserHelper.newline_character)
+        token_parts.extend(["</blockquote>", ParserHelper.newline_character])
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
 
 
 # pylint: enable=too-many-instance-attributes

--- a/pymarkdown/tokens/email_autolink_markdown_token.py
+++ b/pymarkdown/tokens/email_autolink_markdown_token.py
@@ -5,7 +5,7 @@ Module to provide for an encapsulation of the inline email autolink element.
 from typing import List, Optional, cast
 
 from pymarkdown.tokens.html_items import (
-    AutolinkTextItem,
+    EmailAutolinkTextItem,
     HtmlCloseTagItem,
     HtmlItems,
     HtmlOpenTagItem,
@@ -132,7 +132,7 @@ class EmailAutolinkMarkdownToken(InlineMarkdownToken):
         output_parts.append(
             HtmlOpenTagItem("a", {"href": f"mailto:{email_token.autolink_text}"})
         )
-        output_parts.append(AutolinkTextItem(email_token.autolink_text))
+        output_parts.append(EmailAutolinkTextItem(email_token.autolink_text))
         output_parts.append(HtmlCloseTagItem("a"))
 
         return cls.__handle_email_autolink_token_old(output_html, email_token)

--- a/pymarkdown/tokens/email_autolink_markdown_token.py
+++ b/pymarkdown/tokens/email_autolink_markdown_token.py
@@ -2,8 +2,9 @@
 Module to provide for an encapsulation of the inline email autolink element.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -112,12 +113,18 @@ class EmailAutolinkMarkdownToken(InlineMarkdownToken):
     def __handle_email_autolink_token(
         cls,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         email_token = cast(EmailAutolinkMarkdownToken, next_token)
+        output_parts.append(ZuluHtmlItem("".join(['<a href="mailto:',
+                email_token.autolink_text,
+                '">',
+                email_token.autolink_text,
+                "</a>"])))
         return "".join(
             [
                 output_html,

--- a/pymarkdown/tokens/email_autolink_markdown_token.py
+++ b/pymarkdown/tokens/email_autolink_markdown_token.py
@@ -4,7 +4,12 @@ Module to provide for an encapsulation of the inline email autolink element.
 
 from typing import List, Optional, cast
 
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    AutolinkTextItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -113,18 +118,26 @@ class EmailAutolinkMarkdownToken(InlineMarkdownToken):
     def __handle_email_autolink_token(
         cls,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         email_token = cast(EmailAutolinkMarkdownToken, next_token)
-        output_parts.append(ZuluHtmlItem("".join(['<a href="mailto:',
-                email_token.autolink_text,
-                '">',
-                email_token.autolink_text,
-                "</a>"])))
+
+        output_parts.append(
+            HtmlOpenTagItem("a", {"href": f"mailto:{email_token.autolink_text}"})
+        )
+        output_parts.append(AutolinkTextItem(email_token.autolink_text))
+        output_parts.append(HtmlCloseTagItem("a"))
+
+        return cls.__handle_email_autolink_token_old(output_html, email_token)
+
+    @classmethod
+    def __handle_email_autolink_token_old(
+        cls, output_html: str, email_token: "EmailAutolinkMarkdownToken"
+    ) -> str:
         return "".join(
             [
                 output_html,

--- a/pymarkdown/tokens/emphasis_markdown_token.py
+++ b/pymarkdown/tokens/emphasis_markdown_token.py
@@ -5,7 +5,7 @@ Module to provide for an encapsulation of the inline emphasis element.
 from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import HtmlCloseTagItem, HtmlItems, HtmlOpenTagItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -142,29 +142,31 @@ class EmphasisMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_start_emphasis_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         emphasis_token = cast(EmphasisMarkdownToken, next_token)
+
         if emphasis_token.emphasis_character == "~":
-            output_parts.append(ZuluHtmlItem("<del>"))
-            return f"{output_html}<del>"
-        
-        output_parts.append(ZuluHtmlItem("<em>" if emphasis_token.emphasis_length == 1 else "<strong>"))
-        return "".join(
-            [
-                output_html,
-                "<em>" if emphasis_token.emphasis_length == 1 else "<strong>",
-            ]
+            output_parts.append(HtmlOpenTagItem("del"))
+        else:
+            output_parts.append(
+                HtmlOpenTagItem(
+                    "em" if emphasis_token.emphasis_length == 1 else "strong"
+                )
+            )
+
+        return EmphasisMarkdownToken.__handle_start_emphasis_token_old(
+            output_html, emphasis_token
         )
 
     @staticmethod
     def __handle_end_emphasis_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -174,9 +176,38 @@ class EmphasisMarkdownToken(InlineMarkdownToken):
         emphasis_token = cast(EmphasisMarkdownToken, end_token.start_markdown_token)
 
         if emphasis_token.emphasis_character == "~":
-            output_parts.append(ZuluHtmlItem("</del>"))
+            output_parts.append(HtmlCloseTagItem("del"))
+        else:
+            output_parts.append(
+                HtmlCloseTagItem(
+                    "em" if emphasis_token.emphasis_length == 1 else "strong"
+                )
+            )
+
+        return EmphasisMarkdownToken.__handle_end_emphasis_token_old(
+            output_html, emphasis_token
+        )
+
+    @staticmethod
+    def __handle_start_emphasis_token_old(
+        output_html: str, emphasis_token: "EmphasisMarkdownToken"
+    ) -> str:
+        if emphasis_token.emphasis_character == "~":
+            return f"{output_html}<del>"
+
+        return "".join(
+            [
+                output_html,
+                "<em>" if emphasis_token.emphasis_length == 1 else "<strong>",
+            ]
+        )
+
+    @staticmethod
+    def __handle_end_emphasis_token_old(
+        output_html: str, emphasis_token: "EmphasisMarkdownToken"
+    ) -> str:
+        if emphasis_token.emphasis_character == "~":
             return f"{output_html}</del>"
-        output_parts.append(ZuluHtmlItem("</em>" if emphasis_token.emphasis_length == 1 else "</strong>"))
         return "".join(
             [
                 output_html,

--- a/pymarkdown/tokens/emphasis_markdown_token.py
+++ b/pymarkdown/tokens/emphasis_markdown_token.py
@@ -2,9 +2,10 @@
 Module to provide for an encapsulation of the inline emphasis element.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -141,6 +142,7 @@ class EmphasisMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_start_emphasis_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -148,7 +150,10 @@ class EmphasisMarkdownToken(InlineMarkdownToken):
 
         emphasis_token = cast(EmphasisMarkdownToken, next_token)
         if emphasis_token.emphasis_character == "~":
+            output_parts.append(ZuluHtmlItem("<del>"))
             return f"{output_html}<del>"
+        
+        output_parts.append(ZuluHtmlItem("<em>" if emphasis_token.emphasis_length == 1 else "<strong>"))
         return "".join(
             [
                 output_html,
@@ -159,6 +164,7 @@ class EmphasisMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_end_emphasis_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -168,7 +174,9 @@ class EmphasisMarkdownToken(InlineMarkdownToken):
         emphasis_token = cast(EmphasisMarkdownToken, end_token.start_markdown_token)
 
         if emphasis_token.emphasis_character == "~":
+            output_parts.append(ZuluHtmlItem("</del>"))
             return f"{output_html}</del>"
+        output_parts.append(ZuluHtmlItem("</em>" if emphasis_token.emphasis_length == 1 else "</strong>"))
         return "".join(
             [
                 output_html,

--- a/pymarkdown/tokens/end_of_stream_token.py
+++ b/pymarkdown/tokens/end_of_stream_token.py
@@ -1,5 +1,10 @@
-from typing import Optional
+"""
+Module to provide for an encapsulation of the end of stream element.
+"""
 
+from typing import List, Optional
+
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.markdown_token import MarkdownToken, MarkdownTokenClass
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_markdown.markdown_transform_context import (
@@ -82,9 +87,9 @@ class EndOfStreamToken(SpecialMarkdownToken):
     @staticmethod
     def __handle_end_of_stream_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
-        _ = (transform_state, next_token)
-
+        _ = (transform_state, next_token, output_parts)
         return output_html

--- a/pymarkdown/tokens/end_of_stream_token.py
+++ b/pymarkdown/tokens/end_of_stream_token.py
@@ -2,8 +2,6 @@
 Module to provide for an encapsulation of the end of stream element.
 """
 
-from typing import Optional
-
 from typing import List, Optional
 
 from pymarkdown.tokens.html_items import HtmlItems

--- a/pymarkdown/tokens/end_of_stream_token.py
+++ b/pymarkdown/tokens/end_of_stream_token.py
@@ -87,7 +87,7 @@ class EndOfStreamToken(SpecialMarkdownToken):
     @staticmethod
     def __handle_end_of_stream_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:

--- a/pymarkdown/tokens/fenced_code_block_markdown_token.py
+++ b/pymarkdown/tokens/fenced_code_block_markdown_token.py
@@ -3,14 +3,19 @@ Module to provide for an encapsulation of the fenced code block element.
 """
 
 import logging
-from typing import List, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.text_markdown_token import TextMarkdownToken
@@ -248,6 +253,18 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
             else ""
         )
 
+    @override
+    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
+        if (
+            field_name == "fence_character"
+            and isinstance(field_value, str)
+            and field_value in ["~", "`"]
+        ):
+            self.__fence_character = field_value
+            self.__compose_extra_data_field()
+            return True
+        return super()._modify_token(field_name, field_value)
+
     @staticmethod
     def register_for_html_transform(
         register_handlers: RegisterHtmlTransformHandlersProtocol,
@@ -265,12 +282,90 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
     def __handle_start_fenced_code_block_token(
         cls,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
+        transform_state.is_in_code_block = True
+        transform_state.is_in_fenced_code_block = True
+
         start_fence_token = cast(FencedCodeBlockMarkdownToken, next_token)
-        token_parts : List[str]= []
+
+        attributes_map: Dict[str, str] = {}
+        if start_fence_token.extracted_text:
+            attributes_map["class"] = f"language-{start_fence_token.extracted_text}"
+
+        if (
+            output_parts and output_parts[-1].get_raw_html_text() in ["</ol>", "</ul>"]
+        ) or (
+            (
+                output_parts
+                and output_parts[-1].get_raw_html_text()[-1]
+                != ParserHelper.newline_character
+            )
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenTagItem("pre"))
+        output_parts.append(HtmlOpenTagItem("code", attributes_map))
+
+        return cls.__handle_start_fenced_code_block_token_old(
+            output_html, transform_state, start_fence_token
+        )
+
+    @classmethod
+    def __handle_end_fenced_code_block_token(
+        cls,
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        transform_state.is_in_code_block = False
+        transform_state.is_in_fenced_code_block = False
+
+        # POGGER.debug(f"output_html>>:{output_html}:<<")
+        # POGGER.debug(
+        #     f"last_token>>:{transform_state.actual_tokens[transform_state.actual_token_index - 1]}:<<"
+        # )
+
+        last_output_part_text = ""
+        if output_parts:
+            last_output_part_text = output_parts[-1].get_raw_html_text()
+
+        if (
+            not last_output_part_text.startswith("<code ")
+            and last_output_part_text != "<code>"
+            and last_output_part_text[-1] != ParserHelper.newline_character
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+            POGGER.debug("#1")
+        elif (
+            (last_output_part_text[-1] == ParserHelper.newline_character)
+            and transform_state.last_token
+            and transform_state.last_token.is_text
+        ):
+            POGGER.debug("#2:$", transform_state.last_token)
+            text_token = cast(TextMarkdownToken, transform_state.last_token)
+            end_token = cast(EndMarkdownToken, next_token)
+            if not (end_token.was_forced and text_token.token_text.endswith("\n\x03")):
+                output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        output_parts.append(HtmlCloseTagItem("code"))
+        output_parts.append(HtmlCloseTagItem("pre"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return cls.__handle_end_fenced_code_block_token_old(
+            output_html, transform_state, next_token
+        )
+
+    @classmethod
+    def __handle_start_fenced_code_block_token_old(
+        cls,
+        output_html: str,
+        transform_state: TransformState,
+        start_fence_token: "FencedCodeBlockMarkdownToken",
+    ) -> str:
+        token_parts: List[str] = []
         if (output_html.endswith("</ol>") or output_html.endswith("</ul>")) or (
             output_html and output_html[-1] != ParserHelper.newline_character
         ):
@@ -285,18 +380,16 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
                 [' class="language-', start_fence_token.extracted_text, '"']
             )
         token_parts.append(">")
-        
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+
         token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @classmethod
-    def __handle_end_fenced_code_block_token(
+    def __handle_end_fenced_code_block_token_old(
         cls,
         output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
         transform_state: TransformState,
+        next_token: MarkdownToken,
     ) -> str:
         fenced_token_index = transform_state.actual_token_index - 1
         while not transform_state.actual_tokens[
@@ -319,14 +412,9 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
             )
         inner_tag_parts.append(">")
         inner_tag = "".join(inner_tag_parts)
-
         POGGER.debug(f"inner_tag>>:{inner_tag}:<<")
-        POGGER.debug(f"output_html>>:{output_html}:<<")
-        POGGER.debug(
-            f"last_token>>:{transform_state.actual_tokens[transform_state.actual_token_index - 1]}:<<"
-        )
 
-        token_parts : List[str] = []
+        token_parts: List[str] = []
         if (
             not output_html.endswith(inner_tag)
             and output_html[-1] != ParserHelper.newline_character
@@ -343,24 +431,6 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
             end_token = cast(EndMarkdownToken, next_token)
             if not (end_token.was_forced and text_token.token_text.endswith("\n\x03")):
                 token_parts.append(ParserHelper.newline_character)
-        transform_state.is_in_code_block, transform_state.is_in_fenced_code_block = (
-            False,
-            False,
-        )
         token_parts.extend(["</code></pre>", ParserHelper.newline_character])
-
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         token_parts.insert(0, output_html)
         return "".join(token_parts)
-
-    @override
-    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
-        if (
-            field_name == "fence_character"
-            and isinstance(field_value, str)
-            and field_value in ["~", "`"]
-        ):
-            self.__fence_character = field_value
-            self.__compose_extra_data_field()
-            return True
-        return super()._modify_token(field_name, field_value)

--- a/pymarkdown/tokens/fenced_code_block_markdown_token.py
+++ b/pymarkdown/tokens/fenced_code_block_markdown_token.py
@@ -3,13 +3,14 @@ Module to provide for an encapsulation of the fenced code block element.
 """
 
 import logging
-from typing import Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.text_markdown_token import TextMarkdownToken
@@ -264,11 +265,12 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
     def __handle_start_fenced_code_block_token(
         cls,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         start_fence_token = cast(FencedCodeBlockMarkdownToken, next_token)
-        token_parts = [output_html]
+        token_parts : List[str]= []
         if (output_html.endswith("</ol>") or output_html.endswith("</ul>")) or (
             output_html and output_html[-1] != ParserHelper.newline_character
         ):
@@ -283,12 +285,16 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
                 [' class="language-', start_fence_token.extracted_text, '"']
             )
         token_parts.append(">")
+        
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @classmethod
     def __handle_end_fenced_code_block_token(
         cls,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -320,7 +326,7 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
             f"last_token>>:{transform_state.actual_tokens[transform_state.actual_token_index - 1]}:<<"
         )
 
-        token_parts = [output_html]
+        token_parts : List[str] = []
         if (
             not output_html.endswith(inner_tag)
             and output_html[-1] != ParserHelper.newline_character
@@ -342,6 +348,9 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
             False,
         )
         token_parts.extend(["</code></pre>", ParserHelper.newline_character])
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @override

--- a/pymarkdown/tokens/fenced_code_block_markdown_token.py
+++ b/pymarkdown/tokens/fenced_code_block_markdown_token.py
@@ -331,9 +331,8 @@ class FencedCodeBlockMarkdownToken(LeafMarkdownToken):
         #     f"last_token>>:{transform_state.actual_tokens[transform_state.actual_token_index - 1]}:<<"
         # )
 
-        last_output_part_text = ""
-        if output_parts:
-            last_output_part_text = output_parts[-1].get_raw_html_text()
+        assert output_parts
+        last_output_part_text = output_parts[-1].get_raw_html_text()
 
         if (
             not last_output_part_text.startswith("<code ")

--- a/pymarkdown/tokens/hard_break_markdown_token.py
+++ b/pymarkdown/tokens/hard_break_markdown_token.py
@@ -5,7 +5,11 @@ Module to provide for an encapsulation of the inline hard line break element.
 from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlItems,
+    HtmlOpenCloseTagItem,
+)
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -110,11 +114,17 @@ class HardBreakMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_hard_break_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        output_parts.append(ZuluHtmlItem("".join(["<br />", ParserHelper.newline_character])))
+        output_parts.append(HtmlOpenCloseTagItem("br"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return HardBreakMarkdownToken.__handle_hard_break_token_old(output_html)
+
+    @staticmethod
+    def __handle_hard_break_token_old(output_html: str) -> str:
         return "".join([output_html, "<br />", ParserHelper.newline_character])

--- a/pymarkdown/tokens/hard_break_markdown_token.py
+++ b/pymarkdown/tokens/hard_break_markdown_token.py
@@ -2,9 +2,10 @@
 Module to provide for an encapsulation of the inline hard line break element.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -109,9 +110,11 @@ class HardBreakMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_hard_break_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
+        output_parts.append(ZuluHtmlItem("".join(["<br />", ParserHelper.newline_character])))
         return "".join([output_html, "<br />", ParserHelper.newline_character])

--- a/pymarkdown/tokens/html_block_markdown_token.py
+++ b/pymarkdown/tokens/html_block_markdown_token.py
@@ -3,11 +3,12 @@ Module to provide for an encapsulation of the html block element.
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -114,19 +115,21 @@ class HtmlBlockMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_html_block_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
         transform_state.is_in_html_block = True
-        token_parts = []
+        token_parts : List[str]= []
         if (
             not output_html
             and transform_state.transform_stack
             and transform_state.transform_stack[-1].endswith("<li>")
         ):
             token_parts.append(ParserHelper.newline_character)
+            output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         else:
             previous_token = transform_state.actual_tokens[
                 transform_state.actual_token_index - 1
@@ -140,11 +143,13 @@ class HtmlBlockMarkdownToken(LeafMarkdownToken):
                 or previous_token.is_list_end
             ):
                 token_parts.append(ParserHelper.newline_character)
+                output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_html_block_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:

--- a/pymarkdown/tokens/html_block_markdown_token.py
+++ b/pymarkdown/tokens/html_block_markdown_token.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import FormatOnlyNewLineHtmlItem, HtmlItems
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -115,21 +115,61 @@ class HtmlBlockMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_html_block_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
         transform_state.is_in_html_block = True
-        token_parts : List[str]= []
+
+        if (
+            not output_parts
+            and transform_state.transform_stack_two
+            and transform_state.transform_stack_two[-1][-1].get_raw_html_text()
+            == "<li>"
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        else:
+            previous_token = transform_state.actual_tokens[
+                transform_state.actual_token_index - 1
+            ]
+            if (
+                not previous_token.is_list_end
+                and previous_token.is_paragraph_end
+                and not transform_state.is_in_loose_list
+                or previous_token.is_list_end
+            ):
+                output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return HtmlBlockMarkdownToken.__handle_start_html_block_token_old(
+            output_html, transform_state
+        )
+
+    @staticmethod
+    def __handle_end_html_block_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = (next_token, output_parts)
+
+        transform_state.is_in_html_block = False
+
+        return output_html
+
+    @staticmethod
+    def __handle_start_html_block_token_old(
+        output_html: str, transform_state: TransformState
+    ) -> str:
+        token_parts: List[str] = []
         if (
             not output_html
             and transform_state.transform_stack
             and transform_state.transform_stack[-1].endswith("<li>")
         ):
             token_parts.append(ParserHelper.newline_character)
-            output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         else:
             previous_token = transform_state.actual_tokens[
                 transform_state.actual_token_index - 1
@@ -143,17 +183,4 @@ class HtmlBlockMarkdownToken(LeafMarkdownToken):
                 or previous_token.is_list_end
             ):
                 token_parts.append(ParserHelper.newline_character)
-                output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         return "".join(token_parts)
-
-    @staticmethod
-    def __handle_end_html_block_token(
-        output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
-        transform_state: TransformState,
-    ) -> str:
-        _ = next_token
-
-        transform_state.is_in_html_block = False
-        return output_html

--- a/pymarkdown/tokens/html_items.py
+++ b/pymarkdown/tokens/html_items.py
@@ -1,0 +1,43 @@
+
+
+
+
+from abc import ABC, abstractmethod
+from typing_extensions import override
+
+from pymarkdown.general.parser_helper import ParserHelper
+
+
+class HtmlItems(ABC):
+    @abstractmethod
+    def get_raw_html_text(self) -> str:
+        """
+        Get the raw html text to produce.
+        """
+
+class HtmlStartTagItem(HtmlItems):
+    def __init__(self, tag_name : str):
+        self.__tag_name = tag_name
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return f"<{self.__tag_name}>"
+class HtmlCloseTagItem(HtmlItems):
+    def __init__(self, tag_name : str):
+        self.__tag_name = tag_name
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return f"</{self.__tag_name}>"
+
+class FormatOnlyNewLineHtmlItem(HtmlItems):
+    @override
+    def get_raw_html_text(self) -> str:
+        return ParserHelper.newline_character
+class ZuluHtmlItem(HtmlItems):
+    def __init__(self, raw_html_text : str):
+        self.__raw_html_text = raw_html_text
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__raw_html_text

--- a/pymarkdown/tokens/html_items.py
+++ b/pymarkdown/tokens/html_items.py
@@ -1,3 +1,7 @@
+"""
+Module to encapsulate the transitions from Markdown to HTML.
+"""
+
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
 
@@ -6,7 +10,12 @@ from typing_extensions import override
 from pymarkdown.general.parser_helper import ParserHelper
 
 
+# pylint: disable=too-few-public-methods
 class HtmlItems(ABC):
+    """
+    Base class for all of the HTML items.
+    """
+
     @abstractmethod
     def get_raw_html_text(self) -> str:
         """
@@ -14,7 +23,15 @@ class HtmlItems(ABC):
         """
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class HtmlOpenTagItem(HtmlItems):
+    """
+    Class to encapsulate an HTML Open tag, such as <a>.
+    """
+
     def __init__(self, tag_name: str, attributes: Optional[Dict[str, str]] = None):
         self.__tag_name = tag_name
         self.__attributes = attributes
@@ -29,7 +46,15 @@ class HtmlOpenTagItem(HtmlItems):
         return "".join(parts)
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class HtmlCloseTagItem(HtmlItems):
+    """
+    Class to encapsulate an HTML Close tag, such as </a>.
+    """
+
     def __init__(self, tag_name: str):
         self.__tag_name = tag_name
 
@@ -38,7 +63,15 @@ class HtmlCloseTagItem(HtmlItems):
         return f"</{self.__tag_name}>"
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class HtmlOpenCloseTagItem(HtmlItems):
+    """
+    Class to encapsulate an HTML Open/Close tag, such as <br/>.
+    """
+
     def __init__(self, tag_name: str, attributes: Optional[Dict[str, str]] = None):
         self.__tag_name = tag_name
         self.__attributes = attributes
@@ -54,13 +87,43 @@ class HtmlOpenCloseTagItem(HtmlItems):
         return "".join(parts)
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class FormatOnlyNewLineHtmlItem(HtmlItems):
+    """
+    Class to encapsulate a newline that is mostly inserted for compatability to example format.
+    """
+
     @override
     def get_raw_html_text(self) -> str:
         return ParserHelper.newline_character
 
 
-class AutolinkTextItem(HtmlItems):
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
+class HtmlBlockNewLineHtmlItem(HtmlItems):
+    """
+    Class to encapsulate a newline within an HTML block.
+    """
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return ParserHelper.newline_character
+
+
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
+class EmailAutolinkTextItem(HtmlItems):
+    """
+    Class to encapsulate text content for an email autolink.
+    """
+
     def __init__(self, text_content: str):
         self.__text_content = text_content
 
@@ -69,7 +132,32 @@ class AutolinkTextItem(HtmlItems):
         return self.__text_content
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
+class UriAutolinkTextItem(HtmlItems):
+    """
+    Class to encapsulate text content for an uri autolink.
+    """
+
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class CodeSpanItem(HtmlItems):
+    """
+    Class to encapsulate text content for a codespan.
+    """
+
     def __init__(self, text_content: str):
         self.__text_content = text_content
 
@@ -78,7 +166,15 @@ class CodeSpanItem(HtmlItems):
         return self.__text_content
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class CodeBlockItem(HtmlItems):
+    """
+    Class to encapsulate text content for a code block.
+    """
+
     def __init__(self, text_content: str):
         self.__text_content = text_content
 
@@ -87,7 +183,17 @@ class CodeBlockItem(HtmlItems):
         return self.__text_content
 
 
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
 class HtmlBlockItem(HtmlItems):
+    """
+    Class to encapsulate text content for a html block.
+
+    Note that this content "looks" like valid HTML but may not be valid HTML.
+    """
+
     def __init__(self, text_content: str):
         self.__text_content = text_content
 
@@ -96,25 +202,17 @@ class HtmlBlockItem(HtmlItems):
         return self.__text_content
 
 
-class SetExtTextItem(HtmlItems):
-    def __init__(self, text_content: str):
-        self.__text_content = text_content
-
-    @override
-    def get_raw_html_text(self) -> str:
-        return self.__text_content
+# pylint: enable=too-few-public-methods
 
 
-class NormalTextItem(HtmlItems):
-    def __init__(self, text_content: str):
-        self.__text_content = text_content
-
-    @override
-    def get_raw_html_text(self) -> str:
-        return self.__text_content
-
-
+# pylint: disable=too-few-public-methods
 class SingleRawHtmlItem(HtmlItems):
+    """
+    Class to encapsulate text content for a single HTML element.
+
+    Note that this content "looks" like valid HTML but may not be valid HTML.
+    """
+
     def __init__(self, text_content: str):
         self.__text_content = text_content
 
@@ -123,7 +221,15 @@ class SingleRawHtmlItem(HtmlItems):
         return f"<{self.__text_content}>"
 
 
-class UriAutolinkTextItem(HtmlItems):
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
+class SetExtTextItem(HtmlItems):
+    """
+    Class to encapsulate text content for a setext heading
+    """
+
     def __init__(self, text_content: str):
         self.__text_content = text_content
 
@@ -132,16 +238,21 @@ class UriAutolinkTextItem(HtmlItems):
         return self.__text_content
 
 
-class HtmlBlockNewLineHtmlItem(HtmlItems):
+# pylint: enable=too-few-public-methods
+
+
+# pylint: disable=too-few-public-methods
+class NormalTextItem(HtmlItems):
+    """
+    Class to encapsulate text content for a normal text section.
+    """
+
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
     @override
     def get_raw_html_text(self) -> str:
-        return ParserHelper.newline_character
+        return self.__text_content
 
 
-class ZuluHtmlItem(HtmlItems):
-    def __init__(self, raw_html_text: str):
-        self.__raw_html_text = raw_html_text
-
-    @override
-    def get_raw_html_text(self) -> str:
-        return self.__raw_html_text
+# pylint: enable=too-few-public-methods

--- a/pymarkdown/tokens/html_items.py
+++ b/pymarkdown/tokens/html_items.py
@@ -81,9 +81,8 @@ class HtmlOpenCloseTagItem(HtmlItems):
         parts = [f"<{self.__tag_name}"]
         if self.__attributes:
             parts.extend(f' {i}="{j}"' for i, j in self.__attributes.items())
-        if self.__tag_name.lower() in ["br", "img", "hr"]:
-            parts.append(" ")
-        parts.append("/>")
+        assert self.__tag_name.lower() in ["br", "img", "hr"]
+        parts.extend((" ", "/>"))
         return "".join(parts)
 
 

--- a/pymarkdown/tokens/html_items.py
+++ b/pymarkdown/tokens/html_items.py
@@ -1,8 +1,6 @@
-
-
-
-
 from abc import ABC, abstractmethod
+from typing import Dict, Optional
+
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
@@ -15,27 +13,133 @@ class HtmlItems(ABC):
         Get the raw html text to produce.
         """
 
-class HtmlStartTagItem(HtmlItems):
-    def __init__(self, tag_name : str):
+
+class HtmlOpenTagItem(HtmlItems):
+    def __init__(self, tag_name: str, attributes: Optional[Dict[str, str]] = None):
         self.__tag_name = tag_name
+        self.__attributes = attributes
 
     @override
     def get_raw_html_text(self) -> str:
-        return f"<{self.__tag_name}>"
+        parts = [f"<{self.__tag_name}"]
+
+        if self.__attributes:
+            parts.extend(f' {i}="{j}"' for i, j in self.__attributes.items())
+        parts.append(">")
+        return "".join(parts)
+
+
 class HtmlCloseTagItem(HtmlItems):
-    def __init__(self, tag_name : str):
+    def __init__(self, tag_name: str):
         self.__tag_name = tag_name
 
     @override
     def get_raw_html_text(self) -> str:
         return f"</{self.__tag_name}>"
 
+
+class HtmlOpenCloseTagItem(HtmlItems):
+    def __init__(self, tag_name: str, attributes: Optional[Dict[str, str]] = None):
+        self.__tag_name = tag_name
+        self.__attributes = attributes
+
+    @override
+    def get_raw_html_text(self) -> str:
+        parts = [f"<{self.__tag_name}"]
+        if self.__attributes:
+            parts.extend(f' {i}="{j}"' for i, j in self.__attributes.items())
+        if self.__tag_name.lower() in ["br", "img", "hr"]:
+            parts.append(" ")
+        parts.append("/>")
+        return "".join(parts)
+
+
 class FormatOnlyNewLineHtmlItem(HtmlItems):
     @override
     def get_raw_html_text(self) -> str:
         return ParserHelper.newline_character
+
+
+class AutolinkTextItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class CodeSpanItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class CodeBlockItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class HtmlBlockItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class SetExtTextItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class NormalTextItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class SingleRawHtmlItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return f"<{self.__text_content}>"
+
+
+class UriAutolinkTextItem(HtmlItems):
+    def __init__(self, text_content: str):
+        self.__text_content = text_content
+
+    @override
+    def get_raw_html_text(self) -> str:
+        return self.__text_content
+
+
+class HtmlBlockNewLineHtmlItem(HtmlItems):
+    @override
+    def get_raw_html_text(self) -> str:
+        return ParserHelper.newline_character
+
+
 class ZuluHtmlItem(HtmlItems):
-    def __init__(self, raw_html_text : str):
+    def __init__(self, raw_html_text: str):
         self.__raw_html_text = raw_html_text
 
     @override

--- a/pymarkdown/tokens/image_start_markdown_token.py
+++ b/pymarkdown/tokens/image_start_markdown_token.py
@@ -3,11 +3,12 @@ Module to provide for an encapsulation of the image element.
 """
 
 import logging
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.links.link_helper_properties import LinkHelperProperties
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.link_start_markdown_token import LinkStartMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.reference_markdown_token import ReferenceMarkdownToken
@@ -130,16 +131,15 @@ class ImageStartMarkdownToken(ReferenceMarkdownToken):
     def __handle_image_token(
         cls,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         image_token = cast(ImageStartMarkdownToken, next_token)
-        return "".join(
-            [
-                output_html,
-                '<img src="',
+
+        token_parts = [                '<img src="',
                 image_token.link_uri,
                 '" alt="',
                 image_token.image_alt_text,
@@ -150,5 +150,7 @@ class ImageStartMarkdownToken(ReferenceMarkdownToken):
                     else ""
                 ),
                 "/>",
-            ]
-        )
+        ]
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)

--- a/pymarkdown/tokens/image_start_markdown_token.py
+++ b/pymarkdown/tokens/image_start_markdown_token.py
@@ -3,12 +3,12 @@ Module to provide for an encapsulation of the image element.
 """
 
 import logging
-from typing import List, Optional, cast
+from typing import Dict, List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.links.link_helper_properties import LinkHelperProperties
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import HtmlItems, HtmlOpenCloseTagItem
 from pymarkdown.tokens.link_start_markdown_token import LinkStartMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.reference_markdown_token import ReferenceMarkdownToken
@@ -131,7 +131,7 @@ class ImageStartMarkdownToken(ReferenceMarkdownToken):
     def __handle_image_token(
         cls,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -139,18 +139,29 @@ class ImageStartMarkdownToken(ReferenceMarkdownToken):
 
         image_token = cast(ImageStartMarkdownToken, next_token)
 
-        token_parts = [                '<img src="',
-                image_token.link_uri,
-                '" alt="',
-                image_token.image_alt_text,
-                '" ',
-                (
-                    f'title="{image_token.link_title}" '
-                    if image_token.link_title
-                    else ""
-                ),
-                "/>",
+        attributes_map: Dict[str, str] = {
+            "src": image_token.link_uri,
+            "alt": image_token.image_alt_text,
+        }
+        if image_token.link_title:
+            attributes_map["title"] = image_token.link_title
+
+        output_parts.append(HtmlOpenCloseTagItem("img", attributes_map))
+
+        return cls.__handle_image_token_old(output_html, image_token)
+
+    @classmethod
+    def __handle_image_token_old(
+        cls, output_html: str, image_token: "ImageStartMarkdownToken"
+    ) -> str:
+        token_parts = [
+            '<img src="',
+            image_token.link_uri,
+            '" alt="',
+            image_token.image_alt_text,
+            '" ',
+            (f'title="{image_token.link_title}" ' if image_token.link_title else ""),
+            "/>",
         ]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/indented_code_block_markdown_token.py
+++ b/pymarkdown/tokens/indented_code_block_markdown_token.py
@@ -5,7 +5,13 @@ Module to provide for an encapsulation of the indented code block element.
 from typing import List, Optional
 
 from pymarkdown.general.parser_helper import ParserHelper
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlBlockItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -130,13 +136,68 @@ class IndentedCodeBlockMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_indented_code_block_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        token_parts : List[str] = []
+        transform_state.is_in_code_block = True
+        transform_state.is_in_fenced_code_block = False
+
+        if (
+            not output_parts
+            and transform_state.transform_stack
+            and transform_state.transform_stack[-1].endswith("<li>")
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        elif (
+            output_parts
+            and not isinstance(output_parts[-1], FormatOnlyNewLineHtmlItem)
+            and not (
+                isinstance(output_parts[-1], HtmlBlockItem)
+                and output_parts[-1]
+                .get_raw_html_text()
+                .endswith(ParserHelper.newline_character)
+            )
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenTagItem("pre"))
+        output_parts.append(HtmlOpenTagItem("code"))
+
+        return (
+            IndentedCodeBlockMarkdownToken.__handle_start_indented_code_block_token_old(
+                output_html, transform_state
+            )
+        )
+
+    @staticmethod
+    def __handle_end_indented_code_block_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = next_token
+
+        transform_state.is_in_code_block = False
+
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlCloseTagItem("code"))
+        output_parts.append(HtmlCloseTagItem("pre"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return (
+            IndentedCodeBlockMarkdownToken.__handle_end_indented_code_block_token_old(
+                output_html
+            )
+        )
+
+    @staticmethod
+    def __handle_start_indented_code_block_token_old(
+        output_html: str, transform_state: TransformState
+    ) -> str:
+        token_parts: List[str] = []
         do_add = True
         if (
             not output_html
@@ -153,24 +214,17 @@ class IndentedCodeBlockMarkdownToken(LeafMarkdownToken):
         )
         token_parts.append("<pre><code>")
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         if do_add:
             token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @staticmethod
-    def __handle_end_indented_code_block_token(
-        output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
-        transform_state: TransformState,
-    ) -> str:
-        _ = next_token
+    def __handle_end_indented_code_block_token_old(output_html: str) -> str:
 
-        transform_state.is_in_code_block = False
-        token_parts = [ParserHelper.newline_character,
-                "</code></pre>",
-                ParserHelper.newline_character,]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
+        token_parts = [
+            output_html,
+            ParserHelper.newline_character,
+            "</code></pre>",
+            ParserHelper.newline_character,
+        ]
         return "".join(token_parts)

--- a/pymarkdown/tokens/indented_code_block_markdown_token.py
+++ b/pymarkdown/tokens/indented_code_block_markdown_token.py
@@ -2,9 +2,10 @@
 Module to provide for an encapsulation of the indented code block element.
 """
 
-from typing import Optional
+from typing import List, Optional
 
 from pymarkdown.general.parser_helper import ParserHelper
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -129,43 +130,47 @@ class IndentedCodeBlockMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_indented_code_block_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        token_parts = []
+        token_parts : List[str] = []
+        do_add = True
         if (
             not output_html
             and transform_state.transform_stack
             and transform_state.transform_stack[-1].endswith("<li>")
         ):
             token_parts.append(ParserHelper.newline_character)
+            do_add = False
         elif output_html and output_html[-1] != ParserHelper.newline_character:
-            token_parts.extend([output_html, ParserHelper.newline_character])
-        else:
-            token_parts.append(output_html)
+            token_parts.extend([ParserHelper.newline_character])
         transform_state.is_in_code_block, transform_state.is_in_fenced_code_block = (
             True,
             False,
         )
         token_parts.append("<pre><code>")
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        if do_add:
+            token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_indented_code_block_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
         transform_state.is_in_code_block = False
-        return "".join(
-            [
-                output_html,
-                ParserHelper.newline_character,
+        token_parts = [ParserHelper.newline_character,
                 "</code></pre>",
-                ParserHelper.newline_character,
-            ]
-        )
+                ParserHelper.newline_character,]
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)

--- a/pymarkdown/tokens/inline_code_span_markdown_token.py
+++ b/pymarkdown/tokens/inline_code_span_markdown_token.py
@@ -2,11 +2,12 @@
 Module to provide for an encapsulation of the inline code span element.
 """
 
-from typing import Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -207,6 +208,7 @@ class InlineCodeSpanMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_inline_code_span_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -234,11 +236,9 @@ class InlineCodeSpanMarkdownToken(InlineMarkdownToken):
                 span_index = next_bar_index + 1
             span_text = new_span_text
 
-        return "".join(
-            [
-                output_html,
-                "<code>",
+        token_parts = ["<code>",
                 ParserHelper.resolve_all_from_text(span_text),
-                "</code>",
-            ]
-        )
+                "</code>"]
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)

--- a/pymarkdown/tokens/inline_code_span_markdown_token.py
+++ b/pymarkdown/tokens/inline_code_span_markdown_token.py
@@ -7,7 +7,12 @@ from typing import List, Optional, Union, cast
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    CodeSpanItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -208,7 +213,7 @@ class InlineCodeSpanMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_inline_code_span_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -236,9 +241,20 @@ class InlineCodeSpanMarkdownToken(InlineMarkdownToken):
                 span_index = next_bar_index + 1
             span_text = new_span_text
 
-        token_parts = ["<code>",
-                ParserHelper.resolve_all_from_text(span_text),
-                "</code>"]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        output_parts.append(HtmlOpenTagItem("code"))
+        output_parts.append(CodeSpanItem(ParserHelper.resolve_all_from_text(span_text)))
+        output_parts.append(HtmlCloseTagItem("code"))
+
+        return InlineCodeSpanMarkdownToken.__handle_inline_code_span_token_old(
+            output_html, span_text
+        )
+
+    @staticmethod
+    def __handle_inline_code_span_token_old(output_html: str, span_text: str) -> str:
+        token_parts = [
+            "<code>",
+            ParserHelper.resolve_all_from_text(span_text),
+            "</code>",
+        ]
         token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/link_reference_definition_markdown_token.py
+++ b/pymarkdown/tokens/link_reference_definition_markdown_token.py
@@ -321,7 +321,7 @@ class LinkReferenceDefinitionMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_link_reference_definition_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:

--- a/pymarkdown/tokens/link_reference_definition_markdown_token.py
+++ b/pymarkdown/tokens/link_reference_definition_markdown_token.py
@@ -11,6 +11,7 @@ from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.links.link_reference_info import LinkReferenceInfo
 from pymarkdown.links.link_reference_titles import LinkReferenceTitles
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -320,10 +321,11 @@ class LinkReferenceDefinitionMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_link_reference_definition_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
-        _ = (transform_state, next_token)
+        _ = (transform_state, next_token, output_parts)
 
         return output_html
 

--- a/pymarkdown/tokens/link_start_markdown_token.py
+++ b/pymarkdown/tokens/link_start_markdown_token.py
@@ -9,7 +9,7 @@ from pymarkdown.general.constants import Constants
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.links.link_helper_properties import LinkHelperProperties
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import HtmlCloseTagItem, HtmlItems, HtmlOpenTagItem
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
 from pymarkdown.tokens.reference_markdown_token import ReferenceMarkdownToken
@@ -240,31 +240,50 @@ class LinkStartMarkdownToken(ReferenceMarkdownToken):
     @staticmethod
     def __handle_start_link_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         link_token = cast(LinkStartMarkdownToken, next_token)
-        token_parts =             [
-                '<a href="',
-                link_token.link_uri,
-                f'" title="{link_token.link_title}' if link_token.link_title else "",
-                '">',
-            ]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+
+        attributes_map = {"href": link_token.link_uri}
+        if link_token.link_title:
+            attributes_map["title"] = link_token.link_title
+
+        output_parts.append(HtmlOpenTagItem("a", attributes_map))
+
+        return LinkStartMarkdownToken.__handle_start_link_token_old(
+            output_html, link_token
+        )
 
     @staticmethod
     def __handle_end_link_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        output_parts.append(ZuluHtmlItem("</a>"))
+        output_parts.append(HtmlCloseTagItem("a"))
+
+        return LinkStartMarkdownToken.__handle_end_link_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_link_token_old(
+        output_html: str, link_token: "LinkStartMarkdownToken"
+    ) -> str:
+        token_parts = [
+            '<a href="',
+            link_token.link_uri,
+            f'" title="{link_token.link_title}' if link_token.link_title else "",
+            '">',
+        ]
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_end_link_token_old(output_html: str) -> str:
         return f"{output_html}</a>"

--- a/pymarkdown/tokens/link_start_markdown_token.py
+++ b/pymarkdown/tokens/link_start_markdown_token.py
@@ -9,6 +9,7 @@ from pymarkdown.general.constants import Constants
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.links.link_helper_properties import LinkHelperProperties
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
 from pymarkdown.tokens.reference_markdown_token import ReferenceMarkdownToken
@@ -239,28 +240,31 @@ class LinkStartMarkdownToken(ReferenceMarkdownToken):
     @staticmethod
     def __handle_start_link_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         link_token = cast(LinkStartMarkdownToken, next_token)
-        return "".join(
-            [
-                output_html,
+        token_parts =             [
                 '<a href="',
                 link_token.link_uri,
                 f'" title="{link_token.link_title}' if link_token.link_title else "",
                 '">',
             ]
-        )
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
 
     @staticmethod
     def __handle_end_link_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
+        output_parts.append(ZuluHtmlItem("</a>"))
         return f"{output_html}</a>"

--- a/pymarkdown/tokens/list_start_markdown_token_helper.py
+++ b/pymarkdown/tokens/list_start_markdown_token_helper.py
@@ -1,6 +1,11 @@
-from typing import cast
+"""
+Module to provide for an encapsulation of the list start element.
+"""
+
+from typing import List, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.list_start_markdown_token import ListStartMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -13,6 +18,7 @@ class ListStartMarkdownTokenHelper:
     @staticmethod
     def handle_start_list_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -41,6 +47,7 @@ class ListStartMarkdownTokenHelper:
     @staticmethod
     def handle_end_list_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:

--- a/pymarkdown/tokens/list_start_markdown_token_helper.py
+++ b/pymarkdown/tokens/list_start_markdown_token_helper.py
@@ -2,10 +2,15 @@
 Module to provide for an encapsulation of the list start element.
 """
 
-from typing import List, cast
+from typing import Dict, List, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
-from pymarkdown.tokens.html_items import HtmlItems
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.list_start_markdown_token import ListStartMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -18,7 +23,7 @@ class ListStartMarkdownTokenHelper:
     @staticmethod
     def handle_start_list_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -30,6 +35,57 @@ class ListStartMarkdownTokenHelper:
                 list_token,
             )
         )
+
+        transform_state.add_leading_parts.clear()
+        if list_token.is_ordered_list_start:
+            attributes_map: Dict[str, str] = {}
+            if int(list_token.list_start_content) != 1:
+                attributes_map["start"] = str(int(list_token.list_start_content))
+            transform_state.add_leading_parts.append(
+                HtmlOpenTagItem("ol", attributes_map)
+            )
+        else:
+            transform_state.add_leading_parts.append(HtmlOpenTagItem("ul"))
+        transform_state.add_leading_parts.append(FormatOnlyNewLineHtmlItem())
+        transform_state.add_leading_parts.append(HtmlOpenTagItem("li"))
+
+        return ListStartMarkdownTokenHelper.__handle_start_list_token_old(
+            output_html, list_token, transform_state
+        )
+
+    @staticmethod
+    def handle_end_list_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = output_parts
+
+        transform_state.is_in_loose_list = (
+            TransformToGfmListLooseness.reset_list_looseness(
+                transform_state.actual_tokens,
+                transform_state.actual_token_index,
+            )
+        )
+
+        transform_state.add_trailing_parts.clear()
+        transform_state.add_trailing_parts.append(HtmlCloseTagItem("li"))
+        transform_state.add_trailing_parts.append(FormatOnlyNewLineHtmlItem())
+        transform_state.add_trailing_parts.append(
+            HtmlCloseTagItem("ul" if next_token.is_unordered_list_end else "ol")
+        )
+
+        return ListStartMarkdownTokenHelper.__handle_end_list_token_old(
+            output_html, next_token, transform_state
+        )
+
+    @staticmethod
+    def __handle_start_list_token_old(
+        output_html: str,
+        list_token: ListStartMarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
         if list_token.is_ordered_list_start:
             token_parts = ["<ol"]
             if int(list_token.list_start_content) != 1:
@@ -42,21 +98,13 @@ class ListStartMarkdownTokenHelper:
             transform_state.add_leading_text = "".join(
                 ["<ul>", ParserHelper.newline_character, "<li>"]
             )
+
         return output_html
 
     @staticmethod
-    def handle_end_list_token(
-        output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
-        transform_state: TransformState,
+    def __handle_end_list_token_old(
+        output_html: str, next_token: MarkdownToken, transform_state: TransformState
     ) -> str:
-        transform_state.is_in_loose_list = (
-            TransformToGfmListLooseness.reset_list_looseness(
-                transform_state.actual_tokens,
-                transform_state.actual_token_index,
-            )
-        )
         transform_state.add_trailing_text = "".join(
             [
                 "</li>",

--- a/pymarkdown/tokens/list_start_markdown_token_helper.py
+++ b/pymarkdown/tokens/list_start_markdown_token_helper.py
@@ -34,6 +34,7 @@ class ListStartMarkdownTokenHelper:
         """
         Handle the HTML transformation for the list start token.
         """
+        _ = output_parts
         list_token = cast(ListStartMarkdownToken, next_token)
         transform_state.is_in_loose_list = (
             TransformToGfmListLooseness.calculate_list_looseness(
@@ -70,6 +71,7 @@ class ListStartMarkdownTokenHelper:
         """
         Handle the HTML transformation for the list end token.
         """
+        _ = output_parts
         transform_state.is_in_loose_list = (
             TransformToGfmListLooseness.reset_list_looseness(
                 transform_state.actual_tokens,

--- a/pymarkdown/tokens/new_list_item_markdown_token.py
+++ b/pymarkdown/tokens/new_list_item_markdown_token.py
@@ -9,7 +9,12 @@ from typing_extensions import override
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.tokens.container_markdown_token import ContainerMarkdownToken
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_markdown.markdown_transform_context import (
@@ -119,19 +124,37 @@ class NewListItemMarkdownToken(ContainerMarkdownToken):
     @staticmethod
     def __handle_new_list_item_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
+        transform_state.add_trailing_parts.clear()
+        transform_state.add_trailing_parts.append(HtmlCloseTagItem("li"))
+        transform_state.add_leading_parts.clear()
+        transform_state.add_leading_parts.append(HtmlOpenTagItem("li"))
+
+        if (
+            output_parts
+            and output_parts[-1].get_raw_html_text()[-1] == ">"
+            and output_parts[-1].get_raw_html_text() != "</a>"
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return NewListItemMarkdownToken.__handle_new_list_item_token_old(
+            output_html, transform_state
+        )
+
+    @staticmethod
+    def __handle_new_list_item_token_old(
+        output_html: str, transform_state: TransformState
+    ) -> str:
         transform_state.add_trailing_text, transform_state.add_leading_text = (
             "</li>",
             "<li>",
         )
-        token_parts : List[str] = []
+        token_parts: List[str] = []
         if output_html and output_html[-1] == ">" and not output_html.endswith("</a>"):
             token_parts.append(ParserHelper.newline_character)
-
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/new_list_item_markdown_token.py
+++ b/pymarkdown/tokens/new_list_item_markdown_token.py
@@ -2,13 +2,14 @@
 Module to provide for an encapsulation of the new list item element.
 """
 
-from typing import Union
+from typing import List, Union
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.tokens.container_markdown_token import ContainerMarkdownToken
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_markdown.markdown_transform_context import (
@@ -118,6 +119,7 @@ class NewListItemMarkdownToken(ContainerMarkdownToken):
     @staticmethod
     def __handle_new_list_item_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -126,7 +128,10 @@ class NewListItemMarkdownToken(ContainerMarkdownToken):
             "</li>",
             "<li>",
         )
-        token_parts = [output_html]
+        token_parts : List[str] = []
         if output_html and output_html[-1] == ">" and not output_html.endswith("</a>"):
             token_parts.append(ParserHelper.newline_character)
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/paragraph_markdown_token.py
+++ b/pymarkdown/tokens/paragraph_markdown_token.py
@@ -9,7 +9,13 @@ from typing_extensions import override
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlBlockItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -97,6 +103,14 @@ class ParagraphMarkdownToken(LeafMarkdownToken):
         self.__final_whitespace = whitespace_to_set
         self.__compose_extra_data_field()
 
+    @override
+    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
+        if field_name == "extracted_whitespace" and isinstance(field_value, str):
+            self.__extracted_whitespace = field_value
+            self.__compose_extra_data_field()
+            return True
+        return False
+
     def register_for_markdown_transform(
         self, registration_function: RegisterMarkdownTransformHandlersProtocol
     ) -> None:
@@ -177,42 +191,65 @@ class ParagraphMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_paragraph_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
-        token_parts : List[str]= []
-        if output_html and output_html[-1] != ParserHelper.newline_character:
-            token_parts.append(ParserHelper.newline_character)
-        if transform_state.is_in_loose_list:
-            token_parts.append("<p>")
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+        if (
+            output_parts
+            and not isinstance(output_parts[-1], FormatOnlyNewLineHtmlItem)
+            and not (
+                isinstance(output_parts[-1], HtmlBlockItem)
+                and output_parts[-1]
+                .get_raw_html_text()
+                .endswith(ParserHelper.newline_character)
+            )
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        if transform_state.is_in_loose_list:
+            output_parts.append(HtmlOpenTagItem("p"))
+
+        return ParagraphMarkdownToken.__handle_start_paragraph_token_old(
+            output_html, transform_state
+        )
 
     @staticmethod
     def __handle_end_paragraph_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
         if transform_state.is_in_loose_list:
-            output_parts.append(ZuluHtmlItem(f"</p>{ParserHelper.newline_character}"))
+            output_parts.append(HtmlCloseTagItem("p"))
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return ParagraphMarkdownToken.__handle_end_paragraph_token_old(
+            output_html, transform_state
+        )
+
+    @staticmethod
+    def __handle_start_paragraph_token_old(
+        output_html: str, transform_state: TransformState
+    ) -> str:
+        token_parts: List[str] = []
+        if output_html and output_html[-1] != ParserHelper.newline_character:
+            token_parts.append(ParserHelper.newline_character)
+        if transform_state.is_in_loose_list:
+            token_parts.append("<p>")
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_end_paragraph_token_old(
+        output_html: str, transform_state: TransformState
+    ) -> str:
         return (
             f"{output_html}</p>{ParserHelper.newline_character}"
             if transform_state.is_in_loose_list
             else output_html
         )
-
-    @override
-    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
-        if field_name == "extracted_whitespace" and isinstance(field_value, str):
-            self.__extracted_whitespace = field_value
-            self.__compose_extra_data_field()
-            return True
-        return False

--- a/pymarkdown/tokens/paragraph_markdown_token.py
+++ b/pymarkdown/tokens/paragraph_markdown_token.py
@@ -2,13 +2,14 @@
 Module to provide for an encapsulation of the paragraph element.
 """
 
-from typing import Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -176,25 +177,32 @@ class ParagraphMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_paragraph_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
-        token_parts = [output_html]
+        token_parts : List[str]= []
         if output_html and output_html[-1] != ParserHelper.newline_character:
             token_parts.append(ParserHelper.newline_character)
         if transform_state.is_in_loose_list:
             token_parts.append("<p>")
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_paragraph_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
+        if transform_state.is_in_loose_list:
+            output_parts.append(ZuluHtmlItem(f"</p>{ParserHelper.newline_character}"))
         return (
             f"{output_html}</p>{ParserHelper.newline_character}"
             if transform_state.is_in_loose_list

--- a/pymarkdown/tokens/raw_html_markdown_token.py
+++ b/pymarkdown/tokens/raw_html_markdown_token.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import HtmlItems, SingleRawHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -54,6 +54,14 @@ class RawHtmlMarkdownToken(InlineMarkdownToken):
         Returns the text that is the raw html tag.
         """
         return self.__raw_tag
+
+    @override
+    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
+        if field_name == "raw_tag" and isinstance(field_value, str):
+            self.__raw_tag = field_value
+            self._set_extra_data(field_value)
+            return True
+        return False
 
     def register_for_markdown_transform(
         self, registration_function: RegisterMarkdownTransformHandlersProtocol
@@ -113,26 +121,33 @@ class RawHtmlMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_raw_html_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         raw_html_token = cast(RawHtmlMarkdownToken, next_token)
-        token_parts =             [
-                "<",
-                ParserHelper.resolve_all_from_text(raw_html_token.raw_tag),
-                ">",
-            ]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+
+        output_parts.append(
+            SingleRawHtmlItem(
+                ParserHelper.resolve_all_from_text(raw_html_token.raw_tag)
+            )
+        )
+
+        return RawHtmlMarkdownToken.__handle_raw_html_token_old(
+            output_html, raw_html_token
+        )
+
+    @staticmethod
+    def __handle_raw_html_token_old(
+        output_html: str, raw_html_token: "RawHtmlMarkdownToken"
+    ) -> str:
+        token_parts = [
+            "<",
+            ParserHelper.resolve_all_from_text(raw_html_token.raw_tag),
+            ">",
+        ]
+
         token_parts.insert(0, output_html)
         return "".join(token_parts)
-
-    @override
-    def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:
-        if field_name == "raw_tag" and isinstance(field_value, str):
-            self.__raw_tag = field_value
-            self._set_extra_data(field_value)
-            return True
-        return False

--- a/pymarkdown/tokens/raw_html_markdown_token.py
+++ b/pymarkdown/tokens/raw_html_markdown_token.py
@@ -3,12 +3,13 @@ Module to provide for an encapsulation of the inline raw html element.
 """
 
 import logging
-from typing import Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -112,20 +113,21 @@ class RawHtmlMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_raw_html_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
 
         raw_html_token = cast(RawHtmlMarkdownToken, next_token)
-        return "".join(
-            [
-                output_html,
+        token_parts =             [
                 "<",
                 ParserHelper.resolve_all_from_text(raw_html_token.raw_tag),
                 ">",
             ]
-        )
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
 
     @override
     def _modify_token(self, field_name: str, field_value: Union[str, int]) -> bool:

--- a/pymarkdown/tokens/setext_heading_markdown_token.py
+++ b/pymarkdown/tokens/setext_heading_markdown_token.py
@@ -2,10 +2,11 @@
 Module to provide for an encapsulation of the setext heading element.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -219,24 +220,29 @@ class SetextHeadingMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_setext_heading_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
         setext_token = cast(SetextHeadingMarkdownToken, next_token)
 
-        token_parts = [output_html]
+        token_parts : List[str] = []
         if output_html.endswith("</ol>") or output_html.endswith("</ul>"):
             token_parts.append(ParserHelper.newline_character)
         token_parts.extend(
             ["<h", "1" if setext_token.heading_character == "=" else "2", ">"]
         )
         transform_state.is_in_setext_block = True
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_setext_heading_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -250,11 +256,13 @@ class SetextHeadingMarkdownToken(LeafMarkdownToken):
             transform_state.actual_tokens[fenced_token_index],
         )
         token_parts = [
-            output_html,
             "</h",
             "1" if fenced_token.heading_character == "=" else "2",
             ">",
             ParserHelper.newline_character,
         ]
         transform_state.is_in_setext_block = False
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/setext_heading_markdown_token.py
+++ b/pymarkdown/tokens/setext_heading_markdown_token.py
@@ -6,7 +6,12 @@ from typing import List, Optional, cast
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.paragraph_markdown_token import ParagraphMarkdownToken
@@ -220,49 +225,77 @@ class SetextHeadingMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_setext_heading_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = transform_state
-        setext_token = cast(SetextHeadingMarkdownToken, next_token)
 
-        token_parts : List[str] = []
-        if output_html.endswith("</ol>") or output_html.endswith("</ul>"):
-            token_parts.append(ParserHelper.newline_character)
-        token_parts.extend(
-            ["<h", "1" if setext_token.heading_character == "=" else "2", ">"]
-        )
         transform_state.is_in_setext_block = True
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+        setext_token = cast(SetextHeadingMarkdownToken, next_token)
+
+        if output_parts and output_parts[-1].get_raw_html_text() in ["</ol>", "</ul>"]:
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(
+            HtmlOpenTagItem("h1" if setext_token.heading_character == "=" else "h2")
+        )
+
+        return SetextHeadingMarkdownToken.__handle_start_setext_heading_token_old(
+            output_html, setext_token
+        )
 
     @staticmethod
     def __handle_end_setext_heading_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
-        fenced_token_index = transform_state.actual_token_index - 1
-        while not transform_state.actual_tokens[fenced_token_index].is_setext_heading:
-            fenced_token_index -= 1
-        fenced_token = cast(
+        transform_state.is_in_setext_block = False
+
+        setext_token_index = transform_state.actual_token_index - 1
+        while not transform_state.actual_tokens[setext_token_index].is_setext_heading:
+            setext_token_index -= 1
+        setext_token = cast(
             SetextHeadingMarkdownToken,
-            transform_state.actual_tokens[fenced_token_index],
+            transform_state.actual_tokens[setext_token_index],
         )
+
+        output_parts.append(
+            HtmlCloseTagItem("h1" if setext_token.heading_character == "=" else "h2")
+        )
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return SetextHeadingMarkdownToken.__handle_end_setext_heading_token_old(
+            output_html, setext_token
+        )
+
+    @staticmethod
+    def __handle_start_setext_heading_token_old(
+        output_html: str,
+        setext_token: "SetextHeadingMarkdownToken",
+    ) -> str:
+        token_parts: List[str] = []
+        if output_html.endswith("</ol>") or output_html.endswith("</ul>"):
+            token_parts.append(ParserHelper.newline_character)
+        token_parts.extend(
+            ["<h", "1" if setext_token.heading_character == "=" else "2", ">"]
+        )
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_end_setext_heading_token_old(
+        output_html: str, setext_token: "SetextHeadingMarkdownToken"
+    ) -> str:
         token_parts = [
             "</h",
-            "1" if fenced_token.heading_character == "=" else "2",
+            "1" if setext_token.heading_character == "=" else "2",
             ">",
             ParserHelper.newline_character,
         ]
-        transform_state.is_in_setext_block = False
-
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/table_markdown_tokens.py
+++ b/pymarkdown/tokens/table_markdown_tokens.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.leaf_blocks.table_block_tuple import TableRow
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -100,6 +101,7 @@ class TableMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -112,17 +114,22 @@ class TableMarkdownToken(LeafMarkdownToken):
             and transform_state.transform_stack[-1].endswith("<li>")
         ):
             token_parts.append(ParserHelper.newline_character)
+            output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         token_parts.extend([output_html, "<table>", ParserHelper.newline_character])
+        output_parts.append(ZuluHtmlItem(f"<table>{ParserHelper.newline_character}"))
+
         return "".join(token_parts)
 
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
+        output_parts.append(ZuluHtmlItem(f"</table>{ParserHelper.newline_character}"))
         return "".join([output_html, "</table>", ParserHelper.newline_character])
 
 
@@ -314,38 +321,41 @@ class TableMarkdownHeaderToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
-        return "".join(
-            [
-                output_html,
+        token_parts =             [
                 "<thead>",
                 ParserHelper.newline_character,
                 "<tr>",
                 ParserHelper.newline_character,
             ]
-        )
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+    
 
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        return "".join(
-            [
-                output_html,
+        token_parts =             [
                 "</tr>",
                 ParserHelper.newline_character,
                 "</thead>",
                 ParserHelper.newline_character,
             ]
-        )
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
 
 
 class TableMarkdownHeaderItemToken(LeafMarkdownToken):
@@ -453,6 +463,7 @@ class TableMarkdownHeaderItemToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -463,6 +474,7 @@ class TableMarkdownHeaderItemToken(LeafMarkdownToken):
             text_to_add = f'<th align="{table_token.column_alignment}">'
         else:
             text_to_add = "<th>"
+        output_parts.append(ZuluHtmlItem(text_to_add))
         return "".join(
             [
                 output_html,
@@ -473,11 +485,13 @@ class TableMarkdownHeaderItemToken(LeafMarkdownToken):
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
+        output_parts.append(ZuluHtmlItem(f"</th>{ParserHelper.newline_character}"))
         return "".join(
             [
                 output_html,
@@ -566,11 +580,13 @@ class TableMarkdownBodyToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
+        output_parts.append(ZuluHtmlItem(f"<tbody>{ParserHelper.newline_character}"))
         return "".join(
             [
                 output_html,
@@ -582,11 +598,13 @@ class TableMarkdownBodyToken(LeafMarkdownToken):
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
+        output_parts.append(ZuluHtmlItem(f"</tbody>{ParserHelper.newline_character}"))
         return "".join([output_html, "</tbody>", ParserHelper.newline_character])
 
 
@@ -741,11 +759,13 @@ class TableMarkdownRowToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
+        output_parts.append(ZuluHtmlItem(f"<tr>{ParserHelper.newline_character}"))
         return "".join(
             [
                 output_html,
@@ -757,21 +777,25 @@ class TableMarkdownRowToken(LeafMarkdownToken):
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:  # sourcery skip: for-append-to-extend, for-index-underscore
         _ = (transform_state, next_token)
 
-        ff = [output_html]
+        token_parts : List[str] = []
         for _i in range(
             cast(
                 TableMarkdownRowToken,
                 cast(EndMarkdownToken, next_token).start_markdown_token,
             ).delta
         ):
-            ff.append("<td></td>\n")
-        ff.extend(("</tr>", ParserHelper.newline_character))
-        return "".join(ff)
+            token_parts.append(f"<td></td>{ParserHelper.newline_character}")
+        token_parts.extend(("</tr>", ParserHelper.newline_character))
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
 
 
 class TableMarkdownRowItemToken(LeafMarkdownToken):
@@ -884,6 +908,7 @@ class TableMarkdownRowItemToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -894,19 +919,19 @@ class TableMarkdownRowItemToken(LeafMarkdownToken):
             text_to_add = f'<td align="{table_token.column_alignment}">'
         else:
             text_to_add = "<td>"
-        return "".join(
-            [
-                output_html,
-                text_to_add,
-            ]
-        )
+        token_parts = [                text_to_add            ]
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
 
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
+        output_parts.append(ZuluHtmlItem(f"</td>{ParserHelper.newline_character}"))
         return "".join([output_html, "</td>", ParserHelper.newline_character])

--- a/pymarkdown/tokens/table_markdown_tokens.py
+++ b/pymarkdown/tokens/table_markdown_tokens.py
@@ -2,14 +2,19 @@
 Module to provide for an encapsulation of the table header markdown token.
 """
 
-from typing import List, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
 from pymarkdown.leaf_blocks.table_block_tuple import TableRow
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -18,6 +23,8 @@ from pymarkdown.transform_markdown.markdown_transform_context import (
     RegisterHtmlTransformHandlersProtocol,
     RegisterMarkdownTransformHandlersProtocol,
 )
+
+# pylint: disable=too-many-lines
 
 
 class TableMarkdownToken(LeafMarkdownToken):
@@ -101,12 +108,44 @@ class TableMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = next_token
 
+        if (
+            not output_parts
+            and transform_state.transform_stack_two
+            and transform_state.transform_stack_two[-1][-1].get_raw_html_text()
+            == "<li>"
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenTagItem("table"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownToken.__handle_start_table_token_old(
+            output_html, transform_state
+        )
+
+    @staticmethod
+    def __handle_end_table_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = (next_token, transform_state)
+
+        output_parts.append(HtmlCloseTagItem("table"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownToken.__handle_end_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_table_token_old(
+        output_html: str, transform_state: TransformState
+    ) -> str:
         token_parts: List[str] = []
         if (
             not output_html
@@ -114,22 +153,13 @@ class TableMarkdownToken(LeafMarkdownToken):
             and transform_state.transform_stack[-1].endswith("<li>")
         ):
             token_parts.append(ParserHelper.newline_character)
-            output_parts.append(ZuluHtmlItem(ParserHelper.newline_character))
         token_parts.extend([output_html, "<table>", ParserHelper.newline_character])
-        output_parts.append(ZuluHtmlItem(f"<table>{ParserHelper.newline_character}"))
-
         return "".join(token_parts)
 
     @staticmethod
-    def __handle_end_table_token(
+    def __handle_end_table_token_old(
         output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
-        transform_state: TransformState,
     ) -> str:
-        _ = (next_token, transform_state)
-
-        output_parts.append(ZuluHtmlItem(f"</table>{ParserHelper.newline_character}"))
         return "".join([output_html, "</table>", ParserHelper.newline_character])
 
 
@@ -321,39 +351,58 @@ class TableMarkdownHeaderToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
-        token_parts =             [
-                "<thead>",
-                ParserHelper.newline_character,
-                "<tr>",
-                ParserHelper.newline_character,
-            ]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
-    
+        output_parts.append(HtmlOpenTagItem("thead"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenTagItem("tr"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownHeaderToken.__handle_start_table_token_old(output_html)
 
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        token_parts =             [
-                "</tr>",
-                ParserHelper.newline_character,
-                "</thead>",
-                ParserHelper.newline_character,
-            ]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        output_parts.append(HtmlCloseTagItem("tr"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlCloseTagItem("thead"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownHeaderToken.__handle_end_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_table_token_old(
+        output_html: str,
+    ) -> str:
+        token_parts = [
+            "<thead>",
+            ParserHelper.newline_character,
+            "<tr>",
+            ParserHelper.newline_character,
+        ]
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_end_table_token_old(
+        output_html: str,
+    ) -> str:
+        token_parts = [
+            "</tr>",
+            ParserHelper.newline_character,
+            "</thead>",
+            ParserHelper.newline_character,
+        ]
         token_parts.insert(0, output_html)
         return "".join(token_parts)
 
@@ -463,18 +512,45 @@ class TableMarkdownHeaderItemToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
         table_token = cast(TableMarkdownHeaderItemToken, next_token)
+
         if table_token.column_alignment:
             text_to_add = f'<th align="{table_token.column_alignment}">'
         else:
             text_to_add = "<th>"
-        output_parts.append(ZuluHtmlItem(text_to_add))
+
+        attributes_map: Dict[str, str] = {}
+        if table_token.column_alignment:
+            attributes_map["align"] = table_token.column_alignment
+
+        output_parts.append(HtmlOpenTagItem("th", attributes_map))
+
+        return TableMarkdownHeaderItemToken.__handle_start_table_token_old(
+            output_html, text_to_add
+        )
+
+    @staticmethod
+    def __handle_end_table_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = (next_token, transform_state)
+
+        output_parts.append(HtmlCloseTagItem("th"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownHeaderItemToken.__handle_end_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_table_token_old(output_html: str, text_to_add: str) -> str:
         return "".join(
             [
                 output_html,
@@ -483,15 +559,7 @@ class TableMarkdownHeaderItemToken(LeafMarkdownToken):
         )
 
     @staticmethod
-    def __handle_end_table_token(
-        output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
-        transform_state: TransformState,
-    ) -> str:
-        _ = (next_token, transform_state)
-
-        output_parts.append(ZuluHtmlItem(f"</th>{ParserHelper.newline_character}"))
+    def __handle_end_table_token_old(output_html: str) -> str:
         return "".join(
             [
                 output_html,
@@ -580,13 +648,35 @@ class TableMarkdownBodyToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
-        output_parts.append(ZuluHtmlItem(f"<tbody>{ParserHelper.newline_character}"))
+        output_parts.append(HtmlOpenTagItem("tbody"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownBodyToken.__handle_start_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_end_table_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = (next_token, transform_state)
+
+        output_parts.append(HtmlCloseTagItem("tbody"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownBodyToken.__handle_end_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_table_token_old(
+        output_html: str,
+    ) -> str:
         return "".join(
             [
                 output_html,
@@ -596,15 +686,9 @@ class TableMarkdownBodyToken(LeafMarkdownToken):
         )
 
     @staticmethod
-    def __handle_end_table_token(
+    def __handle_end_table_token_old(
         output_html: str,
-        output_parts : List[HtmlItems],
-        next_token: MarkdownToken,
-        transform_state: TransformState,
     ) -> str:
-        _ = (next_token, transform_state)
-
-        output_parts.append(ZuluHtmlItem(f"</tbody>{ParserHelper.newline_character}"))
         return "".join([output_html, "</tbody>", ParserHelper.newline_character])
 
 
@@ -759,13 +843,46 @@ class TableMarkdownRowToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
-        output_parts.append(ZuluHtmlItem(f"<tr>{ParserHelper.newline_character}"))
+        output_parts.append(HtmlOpenTagItem("tr"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownRowToken.__handle_start_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_end_table_token(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        next_token: MarkdownToken,
+        transform_state: TransformState,
+    ) -> str:
+        _ = (transform_state, next_token)
+
+        for _i in range(
+            cast(
+                TableMarkdownRowToken,
+                cast(EndMarkdownToken, next_token).start_markdown_token,
+            ).delta
+        ):
+            output_parts.append(HtmlOpenTagItem("td"))
+            output_parts.append(HtmlCloseTagItem("td"))
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+            break
+
+        output_parts.append(HtmlCloseTagItem("tr"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownRowToken.__handle_end_table_token_old(
+            output_html, next_token
+        )
+
+    @staticmethod
+    def __handle_start_table_token_old(output_html: str) -> str:
         return "".join(
             [
                 output_html,
@@ -775,15 +892,12 @@ class TableMarkdownRowToken(LeafMarkdownToken):
         )
 
     @staticmethod
-    def __handle_end_table_token(
+    def __handle_end_table_token_old(
         output_html: str,
-        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
-        transform_state: TransformState,
-    ) -> str:  # sourcery skip: for-append-to-extend, for-index-underscore
-        _ = (transform_state, next_token)
+    ) -> str:
 
-        token_parts : List[str] = []
+        token_parts: List[str] = []
         for _i in range(
             cast(
                 TableMarkdownRowToken,
@@ -791,9 +905,8 @@ class TableMarkdownRowToken(LeafMarkdownToken):
             ).delta
         ):
             token_parts.append(f"<td></td>{ParserHelper.newline_character}")
+            break
         token_parts.extend(("</tr>", ParserHelper.newline_character))
-
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         token_parts.insert(0, output_html)
         return "".join(token_parts)
 
@@ -908,30 +1021,50 @@ class TableMarkdownRowItemToken(LeafMarkdownToken):
     @staticmethod
     def __handle_start_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (transform_state, next_token)
 
         table_token = cast(TableMarkdownRowItemToken, next_token)
+        attributes_map: Dict[str, str] = {}
         if table_token.column_alignment:
-            text_to_add = f'<td align="{table_token.column_alignment}">'
-        else:
-            text_to_add = "<td>"
-        token_parts = [                text_to_add            ]
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+            attributes_map["align"] = table_token.column_alignment
+        output_parts.append(HtmlOpenTagItem("td", attributes_map))
+
+        return TableMarkdownRowItemToken.__handle_start_table_token_old(
+            output_html, table_token
+        )
 
     @staticmethod
     def __handle_end_table_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        output_parts.append(ZuluHtmlItem(f"</td>{ParserHelper.newline_character}"))
+        output_parts.append(HtmlCloseTagItem("td"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return TableMarkdownRowItemToken.__handle_end_table_token_old(output_html)
+
+    @staticmethod
+    def __handle_start_table_token_old(
+        output_html: str, table_token: "TableMarkdownRowItemToken"
+    ) -> str:
+        if table_token.column_alignment:
+            text_to_add = f'<td align="{table_token.column_alignment}">'
+        else:
+            text_to_add = "<td>"
+        token_parts = [text_to_add]
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_end_table_token_old(
+        output_html: str,
+    ) -> str:
         return "".join([output_html, "</td>", ParserHelper.newline_character])

--- a/pymarkdown/tokens/text_markdown_token.py
+++ b/pymarkdown/tokens/text_markdown_token.py
@@ -11,7 +11,13 @@ from pymarkdown.general.constants import Constants
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    CodeBlockItem,
+    HtmlBlockItem,
+    HtmlItems,
+    NormalTextItem,
+    SetExtTextItem,
+)
 from pymarkdown.tokens.indented_code_block_markdown_token import (
     IndentedCodeBlockMarkdownToken,
 )
@@ -523,7 +529,7 @@ class TextMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_text_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -533,58 +539,109 @@ class TextMarkdownToken(InlineMarkdownToken):
         text_token = cast(TextMarkdownToken, next_token)
         adjusted_text_token = ParserHelper.resolve_all_from_text(text_token.token_text)
 
-        token_parts: List[str] = []
         if transform_state.is_in_code_block:
-            POGGER.debug(
-                "text_token.extracted_whitespace>:$:<", text_token.extracted_whitespace
+            return TextMarkdownToken.__handle_text_token_code(
+                output_html, output_parts, text_token, adjusted_text_token
             )
-            leading_space = ParserHelper.resolve_all_from_text(
-                text_token.extracted_whitespace
+        if transform_state.is_in_html_block:
+            return TextMarkdownToken.__handle_text_token_html(
+                output_html, output_parts, text_token, adjusted_text_token
             )
+        if transform_state.is_in_setext_block:
+            return TextMarkdownToken.__handle_text_token_setext(
+                output_html, output_parts, adjusted_text_token
+            )
+        return TextMarkdownToken.__handle_text_token_normal(
+            output_html, output_parts, text_token, adjusted_text_token
+        )
 
-            POGGER.debug("leading_space>:$:<", leading_space)
-            POGGER.debug("adjusted_text_token>:$:<", adjusted_text_token)
-            token_parts.extend(
-                [
-                    leading_space,
-                    adjusted_text_token,
-                ]
-            )
-        elif transform_state.is_in_html_block:
-            POGGER.debug(
-                "text_token.extracted_whitespace>:$:<", text_token.extracted_whitespace
-            )
-            leading_space = ParserHelper.resolve_all_from_text(
-                text_token.extracted_whitespace
-            )
+    @staticmethod
+    def __handle_text_token_code(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        text_token: "TextMarkdownToken",
+        adjusted_text_token: str,
+    ) -> str:
+        token_parts: List[str] = []
+        POGGER.debug(
+            "text_token.extracted_whitespace>:$:<", text_token.extracted_whitespace
+        )
+        leading_space = ParserHelper.resolve_all_from_text(
+            text_token.extracted_whitespace
+        )
 
-            POGGER.debug("leading_space>:$:<", leading_space)
-            POGGER.debug("adjusted_text_token>:$:<", adjusted_text_token)
-            POGGER.debug("newline_character>:$:<", ParserHelper.newline_character)
-            token_parts.extend(
-                [
-                    leading_space,
-                    adjusted_text_token,
-                    ParserHelper.newline_character,
-                ]
-            )
-        elif transform_state.is_in_setext_block:
-            token_parts.append(adjusted_text_token)
-        else:
-            TextMarkdownToken.__handle_text_token_normal(
-                token_parts, text_token, adjusted_text_token
-            )
+        POGGER.debug("leading_space>:$:<", leading_space)
+        POGGER.debug("adjusted_text_token>:$:<", adjusted_text_token)
+        token_parts.extend(
+            [
+                leading_space,
+                adjusted_text_token,
+            ]
+        )
+        if code_block_text := "".join(token_parts):
+            output_parts.append(CodeBlockItem(code_block_text))
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
-        token_parts.insert(0, output_html)
-        return "".join(token_parts)
+        return TextMarkdownToken.__handle_text_token_code_old(output_html, token_parts)
+
+    @staticmethod
+    def __handle_text_token_html(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        text_token: "TextMarkdownToken",
+        adjusted_text_token: str,
+    ) -> str:
+        POGGER.debug(
+            "text_token.extracted_whitespace>:$:<", text_token.extracted_whitespace
+        )
+        leading_space = ParserHelper.resolve_all_from_text(
+            text_token.extracted_whitespace
+        )
+
+        POGGER.debug("leading_space>:$:<", leading_space)
+        POGGER.debug("adjusted_text_token>:$:<", adjusted_text_token)
+        POGGER.debug("newline_character>:$:<", ParserHelper.newline_character)
+        token_parts: List[str] = [
+            leading_space,
+            adjusted_text_token,
+            ParserHelper.newline_character,
+        ]
+        output_parts.append(HtmlBlockItem("".join(token_parts)))
+
+        return TextMarkdownToken.__handle_text_token_html_old(output_html, token_parts)
+
+    @staticmethod
+    def __handle_text_token_setext(
+        output_html: str,
+        output_parts: List[HtmlItems],
+        adjusted_text_token: str,
+    ) -> str:
+        output_parts.append(SetExtTextItem(adjusted_text_token))
+
+        return TextMarkdownToken.__handle_text_token_setext_old(
+            output_html, adjusted_text_token
+        )
 
     @staticmethod
     def __handle_text_token_normal(
-        token_parts: List[str],
+        output_html: str,
+        output_parts: List[HtmlItems],
         text_token: "TextMarkdownToken",
         adjusted_text_token: str,
-    ) -> None:
+    ) -> str:
+        normal_text_content = TextMarkdownToken.__compose_text_token_normal(
+            text_token, adjusted_text_token
+        )
+        output_parts.append(NormalTextItem(normal_text_content))
+
+        return TextMarkdownToken.__handle_text_token_normal_old(
+            output_html, normal_text_content
+        )
+
+    @staticmethod
+    def __compose_text_token_normal(
+        text_token: "TextMarkdownToken",
+        adjusted_text_token: str,
+    ) -> str:
         POGGER.debug("adjusted_text_token>:$:<", adjusted_text_token)
         POGGER.debug("text_token.end_whitespace>:$:<", text_token.end_whitespace)
         if text_token.end_whitespace is not None:
@@ -632,7 +689,7 @@ class TextMarkdownToken(InlineMarkdownToken):
                 final_parts.append(arrays_to_combine[loop_index_mod][loop_index_div])
                 POGGER.debug("final_parts>:$:<", final_parts)
             adjusted_text_token = "".join(final_parts)
-        token_parts.append(adjusted_text_token)
+        return adjusted_text_token
 
     @staticmethod
     def __handle_text_token_normal_enhanced(
@@ -690,3 +747,29 @@ class TextMarkdownToken(InlineMarkdownToken):
         processed_lines.append(current_line)
 
         arrays_to_combine.append(processed_lines)
+
+    @staticmethod
+    def __handle_text_token_code_old(output_html: str, token_parts: List[str]) -> str:
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_text_token_html_old(output_html: str, token_parts: List[str]) -> str:
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_text_token_normal_old(
+        output_html: str, normal_text_content: str
+    ) -> str:
+        token_parts: List[str] = [normal_text_content]
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)
+
+    @staticmethod
+    def __handle_text_token_setext_old(
+        output_html: str, adjusted_text_token: str
+    ) -> str:
+        token_parts: List[str] = [adjusted_text_token]
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)

--- a/pymarkdown/tokens/text_markdown_token.py
+++ b/pymarkdown/tokens/text_markdown_token.py
@@ -11,6 +11,7 @@ from pymarkdown.general.constants import Constants
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.indented_code_block_markdown_token import (
     IndentedCodeBlockMarkdownToken,
 )
@@ -522,6 +523,7 @@ class TextMarkdownToken(InlineMarkdownToken):
     @staticmethod
     def __handle_text_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -573,6 +575,7 @@ class TextMarkdownToken(InlineMarkdownToken):
                 token_parts, text_token, adjusted_text_token
             )
 
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
         token_parts.insert(0, output_html)
         return "".join(token_parts)
 

--- a/pymarkdown/tokens/thematic_break_markdown_token.py
+++ b/pymarkdown/tokens/thematic_break_markdown_token.py
@@ -8,7 +8,12 @@ from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlBlockItem,
+    HtmlItems,
+    HtmlOpenCloseTagItem,
+)
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -129,17 +134,39 @@ class ThematicBreakMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_thematic_break_token(
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        token_parts : List[str]= []
+        if (
+            output_parts
+            and not isinstance(output_parts[-1], FormatOnlyNewLineHtmlItem)
+            and not (
+                isinstance(output_parts[-1], HtmlBlockItem)
+                and output_parts[-1]
+                .get_raw_html_text()
+                .endswith(ParserHelper.newline_character)
+            )
+        ):
+            output_parts.append(FormatOnlyNewLineHtmlItem())
+        output_parts.append(HtmlOpenCloseTagItem("hr"))
+        output_parts.append(FormatOnlyNewLineHtmlItem())
+
+        return ThematicBreakMarkdownToken.__handle_thematic_break_token_old(
+            output_html,
+        )
+
+    @staticmethod
+    def __handle_thematic_break_token_old(
+        output_html: str,
+    ) -> str:
+        token_parts: List[str] = []
+
         if output_html and output_html[-1] != ParserHelper.newline_character:
             token_parts.append(ParserHelper.newline_character)
-        token_parts.extend(["<hr />", ParserHelper.newline_character])
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.extend(["<hr />", ParserHelper.newline_character])
         token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/thematic_break_markdown_token.py
+++ b/pymarkdown/tokens/thematic_break_markdown_token.py
@@ -2,12 +2,13 @@
 Module to provide for an encapsulation of the thematic break element.
 """
 
-from typing import Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 from typing_extensions import override
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.position_marker import PositionMarker
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.leaf_markdown_token import LeafMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -128,13 +129,17 @@ class ThematicBreakMarkdownToken(LeafMarkdownToken):
     @staticmethod
     def __handle_thematic_break_token(
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
         _ = (next_token, transform_state)
 
-        token_parts = [output_html]
+        token_parts : List[str]= []
         if output_html and output_html[-1] != ParserHelper.newline_character:
             token_parts.append(ParserHelper.newline_character)
         token_parts.extend(["<hr />", ParserHelper.newline_character])
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/tokens/uri_autolink_markdown_token.py
+++ b/pymarkdown/tokens/uri_autolink_markdown_token.py
@@ -2,9 +2,10 @@
 Module to provide for an encapsulation of the inline uri autolink element.
 """
 
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 from pymarkdown.inline.inline_helper import InlineHelper
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -137,6 +138,7 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
     def __handle_uri_autolink(
         cls,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -150,7 +152,7 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
             add_text_signature=False,
         )
 
-        tag_text_parts = []
+        tag_text_parts : List[str]= []
         for next_character in in_tag_pretext:
             if (
                 next_character
@@ -164,9 +166,7 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
             else:
                 tag_text_parts.append(next_character)
 
-        return "".join(
-            [
-                output_html,
+        token_parts = [
                 '<a href="',
                 "http://" if autolink_token.add_http_prefix else "",
                 "".join(tag_text_parts),
@@ -176,4 +176,7 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
                 ),
                 "</a>",
             ]
-        )
+
+        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        token_parts.insert(0, output_html)
+        return "".join(token_parts)

--- a/pymarkdown/tokens/uri_autolink_markdown_token.py
+++ b/pymarkdown/tokens/uri_autolink_markdown_token.py
@@ -5,7 +5,12 @@ Module to provide for an encapsulation of the inline uri autolink element.
 from typing import List, Optional, cast
 
 from pymarkdown.inline.inline_helper import InlineHelper
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    HtmlCloseTagItem,
+    HtmlItems,
+    HtmlOpenTagItem,
+    UriAutolinkTextItem,
+)
 from pymarkdown.tokens.inline_markdown_token import InlineMarkdownToken
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -138,7 +143,7 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
     def __handle_uri_autolink(
         cls,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str:
@@ -152,7 +157,7 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
             add_text_signature=False,
         )
 
-        tag_text_parts : List[str]= []
+        tag_text_parts: List[str] = []
         for next_character in in_tag_pretext:
             if (
                 next_character
@@ -166,17 +171,41 @@ class UriAutolinkMarkdownToken(InlineMarkdownToken):
             else:
                 tag_text_parts.append(next_character)
 
-        token_parts = [
-                '<a href="',
-                "http://" if autolink_token.add_http_prefix else "",
-                "".join(tag_text_parts),
-                '">',
+        attributes_map = {
+            "href": ("http://" if autolink_token.add_http_prefix else "")
+            + ("".join(tag_text_parts))
+        }
+
+        output_parts.append(HtmlOpenTagItem("a", attributes_map))
+        output_parts.append(
+            UriAutolinkTextItem(
                 InlineHelper.append_text(
                     "", autolink_token.autolink_text, add_text_signature=False
-                ),
-                "</a>",
-            ]
+                )
+            )
+        )
+        output_parts.append(HtmlCloseTagItem("a"))
 
-        output_parts.append(ZuluHtmlItem("".join(token_parts)))
+        return cls.__handle_uri_autolink_old(
+            output_html, tag_text_parts, autolink_token
+        )
+
+    @classmethod
+    def __handle_uri_autolink_old(
+        cls,
+        output_html: str,
+        tag_text_parts: List[str],
+        autolink_token: "UriAutolinkMarkdownToken",
+    ) -> str:
+        token_parts = [
+            '<a href="',
+            "http://" if autolink_token.add_http_prefix else "",
+            "".join(tag_text_parts),
+            '">',
+            InlineHelper.append_text(
+                "", autolink_token.autolink_text, add_text_signature=False
+            ),
+            "</a>",
+        ]
         token_parts.insert(0, output_html)
         return "".join(token_parts)

--- a/pymarkdown/transform_gfm/transform_state.py
+++ b/pymarkdown/transform_gfm/transform_state.py
@@ -2,7 +2,7 @@
 Module that contains the state of transformation of TransformToGfm.
 """
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.markdown_token import MarkdownToken
@@ -27,8 +27,10 @@ class TransformState:
             self.__actual_tokens,
             self.__actual_token_index,
         ) = (False, False, False, False, True, actual_tokens, 0)
-        self.__add_trailing_text: Optional[str] = None
-        self.__add_leading_text: Optional[str] = None
+        self.__add_trailing_text: str = ""
+        self.__add_leading_text: str = ""
+        self.__add_leading_parts: List[HtmlItems] = []
+        self.__add_trailing_parts: List[HtmlItems] = []
         self.__next_token: Optional[MarkdownToken] = None
         self.__transform_stack: List[str] = []
         self.__transform_stack_two: List[List[HtmlItems]] = []
@@ -110,38 +112,55 @@ class TransformState:
         Stack used to keep track of scope within the generator.
         """
         return self.__transform_stack
-    
+
     @property
     def transform_stack_two(self) -> List[List[HtmlItems]]:
+        """
+        Stack used to keep track of HtmlItems scope within the generator.
+        """
         return self.__transform_stack_two
 
     @property
-    def add_trailing_text(self) -> Optional[str]:
+    def add_trailing_text(self) -> str:
         """
         Keep track of trailing text.
         """
         return self.__add_trailing_text
 
     @add_trailing_text.setter
-    def add_trailing_text(self, value: Optional[str]) -> None:
+    def add_trailing_text(self, value: str) -> None:
         """
         Set trailing text to keep track of.
         """
         self.__add_trailing_text = value
 
     @property
-    def add_leading_text(self) -> Optional[str]:
+    def add_leading_text(self) -> str:
         """
         Keep track of leading text.
         """
         return self.__add_leading_text
 
     @add_leading_text.setter
-    def add_leading_text(self, value: Optional[str]) -> None:
+    def add_leading_text(self, value: str) -> None:
         """
         Set leading text to keep track of.
         """
         self.__add_leading_text = value
+
+    @property
+    def add_leading_parts(self) -> List[HtmlItems]:
+        """
+        Keep track of leading text.
+        """
+        return self.__add_leading_parts
+
+    @property
+    def add_trailing_parts(self) -> List[HtmlItems]:
+        """
+        Keep track of leading text.
+        """
+        return self.__add_trailing_parts
 
     @property
     def next_token(self) -> Optional[MarkdownToken]:

--- a/pymarkdown/transform_gfm/transform_state.py
+++ b/pymarkdown/transform_gfm/transform_state.py
@@ -2,8 +2,9 @@
 Module that contains the state of transformation of TransformToGfm.
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.markdown_token import MarkdownToken
 
 
@@ -30,6 +31,7 @@ class TransformState:
         self.__add_leading_text: Optional[str] = None
         self.__next_token: Optional[MarkdownToken] = None
         self.__transform_stack: List[str] = []
+        self.__transform_stack_two: List[List[HtmlItems]] = []
         self.__last_token: Optional[MarkdownToken] = None
 
     @property
@@ -108,6 +110,10 @@ class TransformState:
         Stack used to keep track of scope within the generator.
         """
         return self.__transform_stack
+    
+    @property
+    def transform_stack_two(self) -> List[List[HtmlItems]]:
+        return self.__transform_stack_two
 
     @property
     def add_trailing_text(self) -> Optional[str]:

--- a/pymarkdown/transform_gfm/transform_to_gfm.py
+++ b/pymarkdown/transform_gfm/transform_to_gfm.py
@@ -7,11 +7,7 @@ from typing import List
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
-from pymarkdown.tokens.html_items import (
-    FormatOnlyNewLineHtmlItem,
-    HtmlItems,
-    ZuluHtmlItem,
-)
+from pymarkdown.tokens.html_items import FormatOnlyNewLineHtmlItem, HtmlItems
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_gfm.transform_to_gfm_token_handlers import (
@@ -178,7 +174,7 @@ class TransformToGfm:
         assert g == transform_state.add_leading_text
 
         if output_html and output_html[-1] != ParserHelper.newline_character:
-            abc.append(ZuluHtmlItem(ParserHelper.newline_character))
+            abc.append(FormatOnlyNewLineHtmlItem())
             output_html = f"{output_html}{ParserHelper.newline_character}{transform_state.add_leading_text}"
         else:
             output_html = f"{output_html}{transform_state.add_leading_text}"

--- a/pymarkdown/transform_gfm/transform_to_gfm.py
+++ b/pymarkdown/transform_gfm/transform_to_gfm.py
@@ -7,6 +7,7 @@ from typing import List
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
+from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_gfm.transform_to_gfm_token_handlers import (
@@ -57,6 +58,8 @@ class TransformToGfm:
             and not transform_state.is_in_fenced_code_block
         ), "Initial state must be set properly."
 
+        output_parts : List[HtmlItems] = []
+
         for next_token in transform_state.actual_tokens:
             output_html = self.__token_handlers.apply_transformation(
                 transform_state,
@@ -64,6 +67,7 @@ class TransformToGfm:
                 actual_tokens_size,
                 next_token,
                 output_html,
+                output_parts,
             )
 
             POGGER.debug("======")
@@ -75,38 +79,49 @@ class TransformToGfm:
             POGGER.debug("output_html    -->$<--", output_html)
 
             if transform_state.add_trailing_text:
-                output_html = self.__apply_trailing_text(output_html, transform_state)
+                output_html = self.__apply_trailing_text(output_html, transform_state, output_parts)
                 POGGER.debug("output_html    -->$<--", output_html)
 
             if transform_state.add_leading_text:
-                output_html = self.__apply_leading_text(output_html, transform_state)
+                output_html = self.__apply_leading_text(output_html, transform_state, output_parts)
                 POGGER.debug("output_html    -->$<--", output_html)
 
             POGGER.debug("------")
             POGGER.debug("next_token     -->$<--", next_token)
             POGGER.debug("output_html    -->$<--", output_html)
             POGGER.debug("transform_stack-->$<--", transform_state.transform_stack)
+            POGGER.debug("transform_stack_two-->$<--", transform_state.transform_stack_two)
 
             transform_state.last_token = next_token
             transform_state.actual_token_index += 1
         if output_html and output_html[-1] == ParserHelper.newline_character:
             output_html = output_html[:-1]
         POGGER.debug("output_html    -->$<--", output_html)
+
+        combined_output_parts = "".join([x.get_raw_html_text() for x in output_parts])
+        if combined_output_parts and combined_output_parts[-1] == ParserHelper.newline_character:
+            combined_output_parts = combined_output_parts[:-1]
+
+        assert output_html == combined_output_parts
+
         return output_html
 
     @classmethod
     def __apply_trailing_text(
-        cls, output_html: str, transform_state: TransformState
+        cls, output_html: str, transform_state: TransformState, abc : List[HtmlItems]
     ) -> str:
         """
         Apply any trailing text to the output.
         """
         POGGER.debug("__apply_trailing_text>:$:<", output_html)
-        stack_text = transform_state.transform_stack.pop()
-        trailing_part = [stack_text]
+
+        trailing_part = [transform_state.transform_stack.pop()]
+        stack_elements = transform_state.transform_stack_two.pop()
+
         for next_token_to_test in TransformToGfm.add_trailing_text_tokens:
             if output_html.startswith(next_token_to_test):
                 trailing_part.append(ParserHelper.newline_character)
+                stack_elements.append(ZuluHtmlItem(ParserHelper.newline_character))
                 break
 
         POGGER.debug("trailing_part>:$:<", trailing_part)
@@ -114,32 +129,46 @@ class TransformToGfm:
             "<blockquote>"
         ):
             trailing_part.append(ParserHelper.newline_character)
+            stack_elements.append(ZuluHtmlItem(ParserHelper.newline_character))
+
         trailing_part.append(output_html)
+        stack_elements.extend(abc)
+
         POGGER.debug("trailing_part>:$:<", trailing_part)
         if output_html.endswith("</ul>") or output_html.endswith("</ol>"):
             trailing_part.append(ParserHelper.newline_character)
+            stack_elements.append(ZuluHtmlItem(ParserHelper.newline_character))
         assert (
             transform_state.add_trailing_text is not None
         ), "Trailing text must be defined by now."
         trailing_part.append(transform_state.add_trailing_text)
+        stack_elements.append(ZuluHtmlItem(transform_state.add_trailing_text))
+
         combined_text = "".join(trailing_part)
         POGGER.debug("__apply_trailing_text>:$:<", combined_text)
+        abc.clear()
+        abc.extend(stack_elements)
         return combined_text
 
     @classmethod
     def __apply_leading_text(
-        cls, output_html: str, transform_state: TransformState
+        cls, output_html: str, transform_state: TransformState, abc : List[HtmlItems]
     ) -> str:
         """
         Apply any leading text to the output.
         """
 
-        output_html = (
-            f"{output_html}{ParserHelper.newline_character}{transform_state.add_leading_text}"
-            if output_html and output_html[-1] != ParserHelper.newline_character
-            else f"{output_html}{transform_state.add_leading_text}"
-        )
+        if output_html and output_html[-1] != ParserHelper.newline_character:
+            abc.append(ZuluHtmlItem(ParserHelper.newline_character))
+            output_html = f"{output_html}{ParserHelper.newline_character}{transform_state.add_leading_text}"
+        else:
+            output_html = f"{output_html}{transform_state.add_leading_text}"
+            
+        assert transform_state.add_leading_text is not None
+        abc.append(ZuluHtmlItem(transform_state.add_leading_text))
         transform_state.transform_stack.append(output_html)
+        transform_state.transform_stack_two.append(abc[:])
+        abc.clear()
         return ""
 
 

--- a/pymarkdown/transform_gfm/transform_to_gfm.py
+++ b/pymarkdown/transform_gfm/transform_to_gfm.py
@@ -7,7 +7,11 @@ from typing import List
 
 from pymarkdown.general.parser_helper import ParserHelper
 from pymarkdown.general.parser_logger import ParserLogger
-from pymarkdown.tokens.html_items import HtmlItems, ZuluHtmlItem
+from pymarkdown.tokens.html_items import (
+    FormatOnlyNewLineHtmlItem,
+    HtmlItems,
+    ZuluHtmlItem,
+)
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 from pymarkdown.transform_gfm.transform_to_gfm_token_handlers import (
@@ -58,7 +62,7 @@ class TransformToGfm:
             and not transform_state.is_in_fenced_code_block
         ), "Initial state must be set properly."
 
-        output_parts : List[HtmlItems] = []
+        output_parts: List[HtmlItems] = []
 
         for next_token in transform_state.actual_tokens:
             output_html = self.__token_handlers.apply_transformation(
@@ -79,18 +83,24 @@ class TransformToGfm:
             POGGER.debug("output_html    -->$<--", output_html)
 
             if transform_state.add_trailing_text:
-                output_html = self.__apply_trailing_text(output_html, transform_state, output_parts)
+                output_html = self.__apply_trailing_text(
+                    output_html, transform_state, output_parts
+                )
                 POGGER.debug("output_html    -->$<--", output_html)
 
             if transform_state.add_leading_text:
-                output_html = self.__apply_leading_text(output_html, transform_state, output_parts)
+                output_html = self.__apply_leading_text(
+                    output_html, transform_state, output_parts
+                )
                 POGGER.debug("output_html    -->$<--", output_html)
 
             POGGER.debug("------")
             POGGER.debug("next_token     -->$<--", next_token)
             POGGER.debug("output_html    -->$<--", output_html)
             POGGER.debug("transform_stack-->$<--", transform_state.transform_stack)
-            POGGER.debug("transform_stack_two-->$<--", transform_state.transform_stack_two)
+            POGGER.debug(
+                "transform_stack_two-->$<--", transform_state.transform_stack_two
+            )
 
             transform_state.last_token = next_token
             transform_state.actual_token_index += 1
@@ -99,7 +109,10 @@ class TransformToGfm:
         POGGER.debug("output_html    -->$<--", output_html)
 
         combined_output_parts = "".join([x.get_raw_html_text() for x in output_parts])
-        if combined_output_parts and combined_output_parts[-1] == ParserHelper.newline_character:
+        if (
+            combined_output_parts
+            and combined_output_parts[-1] == ParserHelper.newline_character
+        ):
             combined_output_parts = combined_output_parts[:-1]
 
         assert output_html == combined_output_parts
@@ -108,12 +121,15 @@ class TransformToGfm:
 
     @classmethod
     def __apply_trailing_text(
-        cls, output_html: str, transform_state: TransformState, abc : List[HtmlItems]
+        cls, output_html: str, transform_state: TransformState, abc: List[HtmlItems]
     ) -> str:
         """
         Apply any trailing text to the output.
         """
         POGGER.debug("__apply_trailing_text>:$:<", output_html)
+
+        g = "".join(i.get_raw_html_text() for i in transform_state.add_trailing_parts)
+        assert g == transform_state.add_trailing_text
 
         trailing_part = [transform_state.transform_stack.pop()]
         stack_elements = transform_state.transform_stack_two.pop()
@@ -121,7 +137,7 @@ class TransformToGfm:
         for next_token_to_test in TransformToGfm.add_trailing_text_tokens:
             if output_html.startswith(next_token_to_test):
                 trailing_part.append(ParserHelper.newline_character)
-                stack_elements.append(ZuluHtmlItem(ParserHelper.newline_character))
+                stack_elements.append(FormatOnlyNewLineHtmlItem())
                 break
 
         POGGER.debug("trailing_part>:$:<", trailing_part)
@@ -129,7 +145,7 @@ class TransformToGfm:
             "<blockquote>"
         ):
             trailing_part.append(ParserHelper.newline_character)
-            stack_elements.append(ZuluHtmlItem(ParserHelper.newline_character))
+            stack_elements.append(FormatOnlyNewLineHtmlItem())
 
         trailing_part.append(output_html)
         stack_elements.extend(abc)
@@ -137,12 +153,9 @@ class TransformToGfm:
         POGGER.debug("trailing_part>:$:<", trailing_part)
         if output_html.endswith("</ul>") or output_html.endswith("</ol>"):
             trailing_part.append(ParserHelper.newline_character)
-            stack_elements.append(ZuluHtmlItem(ParserHelper.newline_character))
-        assert (
-            transform_state.add_trailing_text is not None
-        ), "Trailing text must be defined by now."
+            stack_elements.append(FormatOnlyNewLineHtmlItem())
         trailing_part.append(transform_state.add_trailing_text)
-        stack_elements.append(ZuluHtmlItem(transform_state.add_trailing_text))
+        stack_elements.extend(transform_state.add_trailing_parts)
 
         combined_text = "".join(trailing_part)
         POGGER.debug("__apply_trailing_text>:$:<", combined_text)
@@ -152,22 +165,25 @@ class TransformToGfm:
 
     @classmethod
     def __apply_leading_text(
-        cls, output_html: str, transform_state: TransformState, abc : List[HtmlItems]
+        cls, output_html: str, transform_state: TransformState, abc: List[HtmlItems]
     ) -> str:
         """
         Apply any leading text to the output.
         """
+
+        g = "".join(i.get_raw_html_text() for i in transform_state.add_leading_parts)
+        assert g == transform_state.add_leading_text
 
         if output_html and output_html[-1] != ParserHelper.newline_character:
             abc.append(ZuluHtmlItem(ParserHelper.newline_character))
             output_html = f"{output_html}{ParserHelper.newline_character}{transform_state.add_leading_text}"
         else:
             output_html = f"{output_html}{transform_state.add_leading_text}"
-            
-        assert transform_state.add_leading_text is not None
-        abc.append(ZuluHtmlItem(transform_state.add_leading_text))
+
+        abc.extend(transform_state.add_leading_parts)
         transform_state.transform_stack.append(output_html)
         transform_state.transform_stack_two.append(abc[:])
+
         abc.clear()
         return ""
 

--- a/pymarkdown/transform_gfm/transform_to_gfm_token_handlers.py
+++ b/pymarkdown/transform_gfm/transform_to_gfm_token_handlers.py
@@ -90,13 +90,15 @@ class TransformToGfmTokenHandlers:
         actual_tokens_size: int,
         next_token: MarkdownToken,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
     ) -> str:
         """
         Apply the required tranformation for the current token.
         """
-        transform_state.add_trailing_text = None
-        transform_state.add_leading_text = None
+        transform_state.add_trailing_text = ""
+        transform_state.add_leading_text = ""
+        transform_state.add_leading_parts.clear()
+        transform_state.add_trailing_parts.clear()
         transform_state.next_token = None
 
         if (transform_state.actual_token_index + 1) < actual_tokens_size:
@@ -107,7 +109,9 @@ class TransformToGfmTokenHandlers:
             start_handler_fn = self.__start_token_handlers[next_token.token_name]
             POGGER.debug("next_token>:$:<", next_token)
             POGGER.debug("output_html>:$:<", output_html)
-            output_html = start_handler_fn(output_html, output_parts, next_token, transform_state)
+            output_html = start_handler_fn(
+                output_html, output_parts, next_token, transform_state
+            )
             POGGER.debug("output_html>:$:<", output_html)
 
         elif next_token.is_end_token:
@@ -119,7 +123,9 @@ class TransformToGfmTokenHandlers:
             end_handler_fn = self.__end_token_handlers[end_token.type_name]
             POGGER.debug("end_token>:$:<", end_token)
             POGGER.debug("output_html>:$:<", output_html)
-            output_html = end_handler_fn(output_html, output_parts, end_token, transform_state)
+            output_html = end_handler_fn(
+                output_html, output_parts, end_token, transform_state
+            )
             POGGER.debug("output_html>:$:<", output_html)
         else:
             raise AssertionError(

--- a/pymarkdown/transform_gfm/transform_to_gfm_token_handlers.py
+++ b/pymarkdown/transform_gfm/transform_to_gfm_token_handlers.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, cast
 
 from pymarkdown.extensions.extension_token_types import ExtensionTokenTypes
 from pymarkdown.general.parser_logger import ParserLogger
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.markdown_token import EndMarkdownToken, MarkdownToken
 from pymarkdown.tokens.token_types import TokenTypes
 from pymarkdown.transform_gfm.transform_state import TransformState
@@ -89,6 +90,7 @@ class TransformToGfmTokenHandlers:
         actual_tokens_size: int,
         next_token: MarkdownToken,
         output_html: str,
+        output_parts : List[HtmlItems],
     ) -> str:
         """
         Apply the required tranformation for the current token.
@@ -105,7 +107,7 @@ class TransformToGfmTokenHandlers:
             start_handler_fn = self.__start_token_handlers[next_token.token_name]
             POGGER.debug("next_token>:$:<", next_token)
             POGGER.debug("output_html>:$:<", output_html)
-            output_html = start_handler_fn(output_html, next_token, transform_state)
+            output_html = start_handler_fn(output_html, output_parts, next_token, transform_state)
             POGGER.debug("output_html>:$:<", output_html)
 
         elif next_token.is_end_token:
@@ -117,7 +119,7 @@ class TransformToGfmTokenHandlers:
             end_handler_fn = self.__end_token_handlers[end_token.type_name]
             POGGER.debug("end_token>:$:<", end_token)
             POGGER.debug("output_html>:$:<", output_html)
-            output_html = end_handler_fn(output_html, end_token, transform_state)
+            output_html = end_handler_fn(output_html, output_parts, end_token, transform_state)
             POGGER.debug("output_html>:$:<", output_html)
         else:
             raise AssertionError(

--- a/pymarkdown/transform_markdown/markdown_transform_context.py
+++ b/pymarkdown/transform_markdown/markdown_transform_context.py
@@ -142,7 +142,7 @@ class StartHtmlTokenTransformProtocol(Protocol):
     def __call__(  # noqa: E704
         self,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str: ...  # pragma: no cover
@@ -160,7 +160,7 @@ class EndHtmlTokenTransformProtocol(Protocol):
     def __call__(  # noqa: E704
         self,
         output_html: str,
-        output_parts : List[HtmlItems],
+        output_parts: List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str: ...  # pragma: no cover

--- a/pymarkdown/transform_markdown/markdown_transform_context.py
+++ b/pymarkdown/transform_markdown/markdown_transform_context.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from typing_extensions import Protocol
 
 from pymarkdown.general.parser_logger import ParserLogger
+from pymarkdown.tokens.html_items import HtmlItems
 from pymarkdown.tokens.markdown_token import MarkdownToken
 from pymarkdown.transform_gfm.transform_state import TransformState
 
@@ -141,6 +142,7 @@ class StartHtmlTokenTransformProtocol(Protocol):
     def __call__(  # noqa: E704
         self,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str: ...  # pragma: no cover
@@ -158,6 +160,7 @@ class EndHtmlTokenTransformProtocol(Protocol):
     def __call__(  # noqa: E704
         self,
         output_html: str,
+        output_parts : List[HtmlItems],
         next_token: MarkdownToken,
         transform_state: TransformState,
     ) -> str: ...  # pragma: no cover

--- a/test/test_markdown_extra.py
+++ b/test/test_markdown_extra.py
@@ -17685,6 +17685,47 @@ another list</li>
 
 
 @pytest.mark.gfm
+def test_extra_060x() -> None:
+    """
+    TBD
+    """
+
+    # Arrange
+    source_markdown = """
+```html
+<pre>
+<code>
+something
+</code>
+</pre>
+<code>
+```
+"""
+    expected_tokens = [
+        "[BLANK(1,1):]",
+        "[fcode-block(2,1):`:3:html:::::]",
+        "[text(3,1):\a<\a&lt;\apre\a>\a&gt;\a\n\a<\a&lt;\acode\a>\a&gt;\a\nsomething\n\a<\a&lt;\a/code\a>\a&gt;\a\n\a<\a&lt;\a/pre\a>\a&gt;\a\n\a<\a&lt;\acode\a>\a&gt;\a:]",
+        "[end-fcode-block:::3:False]",
+        "[BLANK(10,1):]",
+    ]
+    expected_gfm = """<pre><code class="language-html">&lt;pre&gt;
+&lt;code&gt;
+something
+&lt;/code&gt;
+&lt;/pre&gt;
+&lt;code&gt;
+</code></pre>"""
+
+    # Act & Assert
+    act_and_assert(
+        source_markdown,
+        expected_gfm,
+        expected_tokens,
+        show_debug=False,
+    )
+
+
+@pytest.mark.gfm
 def test_extra_999() -> None:
     """
     Temporary test to keep coverage up while consistency checks disabled.

--- a/utils/remove_precommit_hook_ids.py
+++ b/utils/remove_precommit_hook_ids.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Script to remove shellcheck hooks from .pre-commit-config.yaml and save to fred.yaml."""
+
+import sys
+from typing import List
+
+import yaml
+
+
+def __remove_shellcheck_repos(
+    input_file: str, output_file: str, id_to_remove: str
+) -> None:
+    """Remove repos containing shellcheck hooks from input YAML and write to output."""
+    with open(input_file, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    if not config or "repos" not in config:
+        print("No repos found in the configuration file.")
+        return
+
+    filtered_repos: List[str] = []
+    for repo in config["repos"]:
+        if "hooks" not in repo:
+            filtered_repos.append(repo)
+            continue
+
+        if filtered_hooks := [
+            hook for hook in repo["hooks"] if hook.get("id") != id_to_remove
+        ]:
+            repo_copy = repo.copy()
+            repo_copy["hooks"] = filtered_hooks
+            filtered_repos.append(repo_copy)
+
+    config["repos"] = filtered_repos
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        yaml.dump(
+            config,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+    print(f"Successfully wrote {output_file} without shellcheck hooks.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(sys.argv)
+        sys.exit(1)
+    __remove_shellcheck_repos(".pre-commit-config.yaml", sys.argv[1], "shellcheck")


### PR DESCRIPTION
## Summary by Sourcery

Refactor the GFM HTML transformation pipeline to build structured HtmlItems alongside the legacy string output, extend transform state and token handlers to support this, and update tooling to optionally skip shellcheck in pre-commit runs.

Enhancements:
- Introduce an HtmlItems abstraction and update HTML transform handlers to populate structured HTML output in parallel with the existing string-based renderer.
- Extend transform state and token handler protocols to track leading/trailing HtmlItems and maintain parallel transform stacks for item-based rendering.
- Refine handling of blockquotes, lists, headings, paragraphs, code blocks, tables, inline elements, and whitespace/newlines to be driven by HtmlItems rather than direct string concatenation.
- Add token-level mutation support for additional fields such as fenced code fence character, block quote leading spaces, paragraph whitespace, and raw HTML tags.

Build:
- Enhance clean.sh to support a --no-shellcheck option by dynamically generating a modified pre-commit config via a new helper script.
- Add a utility script to strip shellcheck hooks from the pre-commit configuration when shellcheck checks are disabled.

Tests:
- Add a GFM test covering fenced HTML code blocks containing nested pre/code tags to validate code block rendering behavior.