### PR TITLE
Issue 1639

### DIFF
--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -10,7 +10,8 @@
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Fixed
 
-- None
+- [Issue 1639](https://github.com/jackdewinter/pymarkdown/issues/1639)
+    - `extensions` and `plugins` commands were not case insensitive
 
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Changed

--- a/newdocs/src/changelog.md
+++ b/newdocs/src/changelog.md
@@ -5,7 +5,8 @@
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Added
 
-- None
+- [Issue 1650](https://github.com/jackdewinter/pymarkdown/issues/1650)
+    - Rules for Md049 (consistent emphasis) and Md050 (consistent strong emphasis)
 
 <!-- pyml disable-next-line no-duplicate-heading-->
 ### Fixed

--- a/newdocs/src/plugins/rule_md049.md
+++ b/newdocs/src/plugins/rule_md049.md
@@ -1,0 +1,82 @@
+# Rule - MD049
+
+| Property | Value |
+| --- | -- |
+| Aliases | `md049`, `emphasis-style` |
+| Autofix Available | No |
+| Enabled By Default | Yes |
+
+## Summary
+
+Emphasis style should be consistent throughout the document.
+
+## Reasoning
+
+### Readability
+
+One of the main keys to readability is to have consistent formatting applied
+throughout a group of documents.  Extending the concept even further,
+organizations may have specific rules on how documents should be authored throughout
+that organization.  It follows that both concepts may extend to specifying
+which character sequence should be used for specifying the start of an inline emphasis
+block in a Markdown document.
+
+## Examples
+
+### Failure Scenarios
+
+This rule triggers when there is inconsistent use for inline emphasis blocks:
+
+````Markdown
+This is *one* emphasis.
+
+This is the _another_ emphasis.
+````
+
+With default configuration settings, the `consistent` style is used.  This
+style sets the current configuration type to either `asterisk` or `underscore`
+based on the first inline emphasis block encountered in the document.
+
+### Correct Scenarios
+
+This rule does not trigger if the character sequence for emphasis blocks is
+consistently specified within the document:
+
+````Markdown
+This is *one* emphasis.
+
+This is the *same* emphasis.
+````
+
+Note that setting the `style` configuration value explicitly to `underscore`
+will cause the above Markdown document to trigger this rule, while a
+value of `asterisk` or `consistent` will not cause this rule to trigger.
+
+## Fix Description
+
+The fix for this rule is currently in queue.
+
+## Configuration
+
+| Prefixes |
+| --- |
+| `plugins.md049.` |
+| `plugins.emphasis-style.` |
+
+| Value Name | Type | Default | Description |
+| -- | -- | -- | -- |
+| `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
+| `style` | string (see below) | `consistent` | Style of emphasis block characters expected in the document. |
+
+Valid styles:
+
+| Style | Description |
+| -- | -- |
+| `consistent` | The first emphasis block in the document specifies the style for the rest of the document. |
+| `asterisk` | Only asterisks are to be used for inline emphasis block elements. |
+| `underscore` | Only underscores are to be used for inline emphasis block elements. |
+
+## Origination of Rule
+
+This rule is largely inspired by the MarkdownLint rule
+[MD049](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md049---emphasis-style).

--- a/newdocs/src/plugins/rule_md050,md
+++ b/newdocs/src/plugins/rule_md050,md
@@ -1,0 +1,82 @@
+# Rule - MD050
+
+| Property | Value |
+| --- | -- |
+| Aliases | `md050`, `strong-style` |
+| Autofix Available | No |
+| Enabled By Default | Yes |
+
+## Summary
+
+Strong emphasis style should be consistent throughout the document.
+
+## Reasoning
+
+### Readability
+
+One of the main keys to readability is to have consistent formatting applied
+throughout a group of documents.  Extending the concept even further,
+organizations may have specific rules on how documents should be authored throughout
+that organization.  It follows that both concepts may extend to specifying
+which character sequence should be used for specifying the start of an inline strong emphasis
+block in a Markdown document.
+
+## Examples
+
+### Failure Scenarios
+
+This rule triggers when there is inconsistent use for inline strong emphasis blocks:
+
+````Markdown
+This is **one** emphasis.
+
+This is the __another__ emphasis.
+````
+
+With default configuration settings, the `consistent` style is used.  This
+style sets the current configuration type to either `asterisk` or `underscore`
+based on the first inline strong emphasis block encountered in the document.
+
+### Correct Scenarios
+
+This rule does not trigger if the character sequence for inline strong emphasis blocks is
+consistently specified within the document:
+
+````Markdown
+This is **one** emphasis.
+
+This is the **same** emphasis.
+````
+
+Note that setting the `style` configuration value explicitly to `underscore`
+will cause the above Markdown document to trigger this rule, while a
+value of `asterisk` or `consistent` will not cause this rule to trigger.
+
+## Fix Description
+
+The fix for this rule is currently in queue.
+
+## Configuration
+
+| Prefixes |
+| --- |
+| `plugins.md050.` |
+| `plugins.strong-style.` |
+
+| Value Name | Type | Default | Description |
+| -- | -- | -- | -- |
+| `enabled` | `boolean` | `True` | Whether the Rule Plugin is enabled. |
+| `style` | string (see below) | `consistent` | Style of inline strong emphasis block characters expected in the document. |
+
+Valid styles:
+
+| Style | Description |
+| -- | -- |
+| `consistent` | The first inline strong emphasis block in the document specifies the style for the rest of the document. |
+| `asterisk` | Only asterisks are to be used for inline strong emphasis block elements. |
+| `underscore` | Only underscores are to be used for inline strong emphasis block elements. |
+
+## Origination of Rule
+
+This rule is largely inspired by the MarkdownLint rule
+[MD050](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md050---strong-style).

--- a/newdocs/src/rules.md
+++ b/newdocs/src/rules.md
@@ -670,6 +670,36 @@ Each file should end with a single newline character.
 
 Code fence style should be consistent throughout the document.
 
+## Rule - MD049
+
+[Full Documentation](./plugins/rule_md049.md)
+
+| Property | Value |
+| --- | -- |
+| Aliases | `md049`, `emphasis-style` |
+| Autofix Available | No |
+| Enabled By Default | Yes |
+
+<!-- pyml disable-next-line no-duplicate-heading-->
+### Summary
+
+Emphasis style should be consistent throughout the document.
+
+## Rule - MD050
+
+[Full Documentation](./plugins/rule_md050,md)
+
+| Property | Value |
+| --- | -- |
+| Aliases | `md050`, `strong-style` |
+| Autofix Available | No |
+| Enabled By Default | Yes |
+
+<!-- pyml disable-next-line no-duplicate-heading-->
+### Summary
+
+Strong emphasis style should be consistent throughout the document.
+
 ## Rule - PML100
 
 [Full Documentation](./plugins/rule_pml100.md)

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -3,11 +3,11 @@
     "reportSource": "Unknown",
     "branchLevel": {
         "totalMeasured": 5986,
-        "totalCovered": 5984
+        "totalCovered": 5986
     },
     "lineLevel": {
         "totalMeasured": 24203,
-        "totalCovered": 24201
+        "totalCovered": 24203
     }
 }
 

--- a/publish/coverage.json
+++ b/publish/coverage.json
@@ -2,12 +2,12 @@
     "projectName": "pymarkdown",
     "reportSource": "Unknown",
     "branchLevel": {
-        "totalMeasured": 5958,
-        "totalCovered": 5958
+        "totalMeasured": 5986,
+        "totalCovered": 5984
     },
     "lineLevel": {
-        "totalMeasured": 24117,
-        "totalCovered": 24117
+        "totalMeasured": 24203,
+        "totalCovered": 24201
     }
 }
 

--- a/publish/pylint_suppression.json
+++ b/publish/pylint_suppression.json
@@ -397,6 +397,8 @@
         "pymarkdown/plugins/rule_md_046.py": {},
         "pymarkdown/plugins/rule_md_047.py": {},
         "pymarkdown/plugins/rule_md_048.py": {},
+        "pymarkdown/plugins/rule_md_049.py": {},
+        "pymarkdown/plugins/rule_md_050.py": {},
         "pymarkdown/plugins/rule_pml_100.py": {},
         "pymarkdown/plugins/rule_pml_101.py": {},
         "pymarkdown/plugins/rule_pml_102.py": {

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -244,7 +244,7 @@
         },
         {
             "name": "test.extensions.test_extension_manager",
-            "totalTests": 17,
+            "totalTests": 19,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,
@@ -1516,7 +1516,7 @@
         },
         {
             "name": "test.rules.test_plugin_manager",
-            "totalTests": 70,
+            "totalTests": 72,
             "failedTests": 0,
             "errorTests": 0,
             "skippedTests": 0,

--- a/publish/test-results.json
+++ b/publish/test-results.json
@@ -1515,6 +1515,22 @@
             "elapsedTimeInMilliseconds": 0
         },
         {
+            "name": "test.rules.test_md049",
+            "totalTests": 19,
+            "failedTests": 0,
+            "errorTests": 0,
+            "skippedTests": 0,
+            "elapsedTimeInMilliseconds": 0
+        },
+        {
+            "name": "test.rules.test_md050",
+            "totalTests": 19,
+            "failedTests": 0,
+            "errorTests": 0,
+            "skippedTests": 0,
+            "elapsedTimeInMilliseconds": 0
+        },
+        {
             "name": "test.rules.test_plugin_manager",
             "totalTests": 72,
             "failedTests": 0,

--- a/pymarkdown/extension_manager/extension_manager.py
+++ b/pymarkdown/extension_manager/extension_manager.py
@@ -246,7 +246,9 @@ class ExtensionManager:
         list_re = None
         if args.list_filter:
             list_re = re.compile(
-                "^" + args.list_filter.replace("*", ".*").replace("?", ".") + "$"
+                "^"
+                + args.list_filter.lower().replace("*", ".*").replace("?", ".")
+                + "$"
             )
 
         names, show_rows = list(self.__extension_details.keys()), []
@@ -294,13 +296,13 @@ class ExtensionManager:
     def __handle_argparse_subparser_info(
         self, args: argparse.Namespace
     ) -> ApplicationResult:
-        if args.info_filter not in self.__extension_details:
+        if args.info_filter.lower() not in self.__extension_details:
             self.__presentation.print_system_error(
                 f"Unable to find an extension with an id of '{args.info_filter}'."
             )
             return ApplicationResult.NO_FILES_TO_SCAN
 
-        found_extension = self.__extension_details[args.info_filter]
+        found_extension = self.__extension_details[args.info_filter.lower()]
         show_rows: List[List[str]] = [
             ["Id", found_extension.extension_id],
             ["Name", found_extension.extension_name],

--- a/pymarkdown/plugin_manager/plugin_manager.py
+++ b/pymarkdown/plugin_manager/plugin_manager.py
@@ -232,7 +232,9 @@ class PluginManager:
     ) -> ApplicationResult:
         list_re = (
             re.compile(
-                "^" + args.list_filter.replace("*", ".*").replace("?", ".") + "$"
+                "^"
+                + args.list_filter.lower().replace("*", ".*").replace("?", ".")
+                + "$"
             )
             if args.list_filter
             else None
@@ -301,7 +303,7 @@ class PluginManager:
     ) -> ApplicationResult:
         matching_plugins: List[FoundPlugin] = list(
             filter(
-                lambda x: args.info_filter in x.plugin_identifiers,
+                lambda x: args.info_filter.lower() in x.plugin_identifiers,
                 self.__registered_plugins,
             )
         )

--- a/pymarkdown/plugins/rule_md_049.py
+++ b/pymarkdown/plugins/rule_md_049.py
@@ -1,0 +1,125 @@
+"""
+Module to implement a plugin that ensures that the style of emphasis is consistent.
+"""
+
+from typing import List, cast
+
+from pymarkdown.plugin_manager.plugin_details import (
+    PluginDetailsV2,
+    PluginDetailsV3,
+    QueryConfigItem,
+)
+from pymarkdown.plugin_manager.plugin_scan_context import PluginScanContext
+from pymarkdown.plugin_manager.rule_plugin import RulePlugin
+from pymarkdown.tokens.emphasis_markdown_token import EmphasisMarkdownToken
+from pymarkdown.tokens.markdown_token import MarkdownToken
+
+
+class RuleMd049(RulePlugin):
+    """
+    Class to implement a plugin that ensures that the style of emphasis is consistent.
+    """
+
+    __consistent_style = "consistent"
+    __asterisk_style = "asterisk"
+    __underscore_style = "underscore"
+    __valid_styles = [
+        __consistent_style,
+        __asterisk_style,
+        __underscore_style,
+    ]
+
+    def __init__(self) -> None:
+        """
+        Initialize an instance of the RuleMd048 class.
+        """
+        super().__init__()
+        self.__style_type: str = ""
+        self.__actual_style_type: str = ""
+
+    def get_details(self) -> PluginDetailsV2:
+        """
+        Get the details for the plugin.
+        """
+        return PluginDetailsV3(
+            plugin_name="emphasis-style",
+            plugin_id="MD049",
+            plugin_enabled_by_default=True,
+            plugin_description="Emphasis style",
+            plugin_version="0.5.0",
+            plugin_url="https://pymarkdown.readthedocs.io/en/latest/plugins/rule_md049.md",
+            plugin_configuration="style",
+            # plugin_supports_fix=True,
+            # plugin_fix_level=2,
+        )
+
+    @classmethod
+    def __validate_configuration_style(cls, found_value: str) -> None:
+        if found_value not in RuleMd049.__valid_styles:
+            raise ValueError(f"Allowable values: {RuleMd049.__valid_styles}")
+
+    def initialize_from_config(self) -> None:
+        """
+        Event to allow the plugin to load configuration information.
+        """
+        self.__style_type = self.plugin_configuration.get_string_property_with_default(
+            "style",
+            RuleMd049.__consistent_style,
+            valid_value_fn=self.__validate_configuration_style,
+        )
+
+    def query_config(self) -> List[QueryConfigItem]:
+        """
+        Query to find out the configuration that the rule is using.
+        """
+        return [
+            QueryConfigItem("style", self.__style_type),
+        ]
+
+    def starting_new_file(self) -> None:
+        """
+        Event that the a new file to be scanned is starting.
+        """
+        self.__actual_style_type = (
+            self.__style_type
+            if self.__style_type != RuleMd049.__consistent_style
+            else ""
+        )
+
+    def next_token(self, context: PluginScanContext, token: MarkdownToken) -> None:
+        """
+        Event that a new token is being processed.
+        """
+        if not token.is_inline_emphasis:
+            return
+
+        emphasis_token = cast(EmphasisMarkdownToken, token)
+        if emphasis_token.emphasis_length != 1:
+            return
+
+        if emphasis_token.emphasis_character == "*":
+            current_style = RuleMd049.__asterisk_style
+        elif emphasis_token.emphasis_character == "_":
+            current_style = RuleMd049.__underscore_style
+        else:
+            return
+
+        if not self.__actual_style_type:
+            self.__actual_style_type = current_style
+        if self.__actual_style_type != current_style:
+            #     if context.in_fix_mode:
+            #         replace_character = (
+            #             "`"
+            #             if self.__actual_style_type == RuleMd048.__backtick_style
+            #             else "~"
+            #         )
+            #         self.register_fix_token_request(
+            #             context, token, "next_token", "fence_character", replace_character
+            #         )
+            #     else:
+            extra_data = (
+                f"Expected: {self.__actual_style_type}; Actual: {current_style}"
+            )
+            self.report_next_token_error(
+                context, token, extra_error_information=extra_data
+            )

--- a/pymarkdown/plugins/rule_md_050.py
+++ b/pymarkdown/plugins/rule_md_050.py
@@ -1,0 +1,125 @@
+"""
+Module to implement a plugin that ensures that the style of strong emphasis is consistent.
+"""
+
+from typing import List, cast
+
+from pymarkdown.plugin_manager.plugin_details import (
+    PluginDetailsV2,
+    PluginDetailsV3,
+    QueryConfigItem,
+)
+from pymarkdown.plugin_manager.plugin_scan_context import PluginScanContext
+from pymarkdown.plugin_manager.rule_plugin import RulePlugin
+from pymarkdown.tokens.emphasis_markdown_token import EmphasisMarkdownToken
+from pymarkdown.tokens.markdown_token import MarkdownToken
+
+
+class RuleMd050(RulePlugin):
+    """
+    Class to implement a plugin that ensures that the style of strong emphasis is consistent.
+    """
+
+    __consistent_style = "consistent"
+    __asterisk_style = "asterisk"
+    __underscore_style = "underscore"
+    __valid_styles = [
+        __consistent_style,
+        __asterisk_style,
+        __underscore_style,
+    ]
+
+    def __init__(self) -> None:
+        """
+        Initialize an instance of the RuleMd048 class.
+        """
+        super().__init__()
+        self.__style_type: str = ""
+        self.__actual_style_type: str = ""
+
+    def get_details(self) -> PluginDetailsV2:
+        """
+        Get the details for the plugin.
+        """
+        return PluginDetailsV3(
+            plugin_name="strong-style",
+            plugin_id="MD050",
+            plugin_enabled_by_default=True,
+            plugin_description="Strong style",
+            plugin_version="0.5.0",
+            plugin_url="https://pymarkdown.readthedocs.io/en/latest/plugins/rule_md050.md",
+            plugin_configuration="style",
+            # plugin_supports_fix=True,
+            # plugin_fix_level=2,
+        )
+
+    @classmethod
+    def __validate_configuration_style(cls, found_value: str) -> None:
+        if found_value not in RuleMd050.__valid_styles:
+            raise ValueError(f"Allowable values: {RuleMd050.__valid_styles}")
+
+    def initialize_from_config(self) -> None:
+        """
+        Event to allow the plugin to load configuration information.
+        """
+        self.__style_type = self.plugin_configuration.get_string_property_with_default(
+            "style",
+            RuleMd050.__consistent_style,
+            valid_value_fn=self.__validate_configuration_style,
+        )
+
+    def query_config(self) -> List[QueryConfigItem]:
+        """
+        Query to find out the configuration that the rule is using.
+        """
+        return [
+            QueryConfigItem("style", self.__style_type),
+        ]
+
+    def starting_new_file(self) -> None:
+        """
+        Event that the a new file to be scanned is starting.
+        """
+        self.__actual_style_type = (
+            self.__style_type
+            if self.__style_type != RuleMd050.__consistent_style
+            else ""
+        )
+
+    def next_token(self, context: PluginScanContext, token: MarkdownToken) -> None:
+        """
+        Event that a new token is being processed.
+        """
+        if not token.is_inline_emphasis:
+            return
+
+        emphasis_token = cast(EmphasisMarkdownToken, token)
+        if emphasis_token.emphasis_length != 2:
+            return
+
+        if emphasis_token.emphasis_character == "*":
+            current_style = RuleMd050.__asterisk_style
+        elif emphasis_token.emphasis_character == "_":
+            current_style = RuleMd050.__underscore_style
+        else:
+            return
+
+        if not self.__actual_style_type:
+            self.__actual_style_type = current_style
+        if self.__actual_style_type != current_style:
+            #     if context.in_fix_mode:
+            #         replace_character = (
+            #             "`"
+            #             if self.__actual_style_type == RuleMd048.__backtick_style
+            #             else "~"
+            #         )
+            #         self.register_fix_token_request(
+            #             context, token, "next_token", "fence_character", replace_character
+            #         )
+            #     else:
+            extra_data = (
+                f"Expected: {self.__actual_style_type}; Actual: {current_style}"
+            )
+            self.report_next_token_error(
+                context, token, extra_error_information=extra_data
+            )

--- a/test/extensions/test_extension_manager.py
+++ b/test/extensions/test_extension_manager.py
@@ -211,6 +211,45 @@ def test_markdown_with_extensions_list_and_filter_by_id_ends_with_r_and_configur
             os.remove(configuration_file)
 
 
+def test_markdown_with_extensions_list_and_filter_by_bad_case_id(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the command line interface to extensions
+    only shows the installed extensions when asked for a list. With id with bad case.
+    """
+
+    # Arrange
+    supplied_configuration = {"extensions": {"front-matter": {"enabled": False}}}
+    configuration_file = None
+    try:
+        configuration_file = write_temporary_configuration(supplied_configuration)
+        supplied_arguments = [
+            "-c",
+            configuration_file,
+            "extensions",
+            "list",
+            "Front-Matter",
+        ]
+
+        expected_results = ExpectedResults(expected_output="""
+  ID            NAME                   ENABLED    ENABLED    VERSION
+                                       (DEFAULT)  (CURRENT)
+
+  front-matter  Front Matter Metadata  False      False      0.5.0
+
+""")
+
+        # Act
+        execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+        # Assert
+        execute_results.assert_results(expected_results=expected_results)
+    finally:
+        if configuration_file and os.path.exists(configuration_file):
+            os.remove(configuration_file)
+
+
 def test_markdown_with_extensions_error_during_configuration(
     scanner_default: MarkdownScanner,
 ) -> None:
@@ -523,6 +562,35 @@ def test_markdown_with_extensions_info_and_found_filter(
 
     # Arrange
     supplied_arguments = ["extensions", "info", "front-matter"]
+
+    expected_results = ExpectedResults(
+        expected_output="""  ITEM               DESCRIPTION
+
+  Id                 front-matter
+  Name               Front Matter Metadata
+  Short Description  Allows metadata to be parsed from document front matter.
+  Description Url    https://pymarkdown.readthedocs.io/en/latest/extensions/fr
+                     ont-matter/
+"""
+    )
+
+    # Act
+    execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+    # Assert
+    execute_results.assert_results(expected_results=expected_results)
+
+
+def test_markdown_with_extensions_info_and_mixed_case_found_filter(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure the command line interface to extensions
+    info presents information when a valid id is supplied, even if it has the wrong case.
+    """
+
+    # Arrange
+    supplied_arguments = ["extensions", "info", "Front-Matter"]
 
     expected_results = ExpectedResults(
         expected_output="""  ITEM               DESCRIPTION

--- a/test/resources/rules/md049/bad_fenced_backticks_and_tildes.md
+++ b/test/resources/rules/md049/bad_fenced_backticks_and_tildes.md
@@ -1,0 +1,9 @@
+```Python
+def test():
+    print("test")
+```
+
+~~~Python
+def test():
+    print("test")
+~~~

--- a/test/resources/rules/md050/bad_fenced_backticks_and_tildes.md
+++ b/test/resources/rules/md050/bad_fenced_backticks_and_tildes.md
@@ -1,0 +1,9 @@
+```Python
+def test():
+    print("test")
+```
+
+~~~Python
+def test():
+    print("test")
+~~~

--- a/test/rules/test_md037.py
+++ b/test/rules/test_md037.py
@@ -21,6 +21,7 @@ scanTests = [
     pluginRuleTest(
         "good_valid_emphasis",
         source_file_name=f"{source_path}good_valid_emphasis.md",
+        disable_rules="md049,md050",
     ),
     pluginRuleTest(
         "bad_surrounding_emphasis",

--- a/test/rules/test_md049.py
+++ b/test/rules/test_md049.py
@@ -99,8 +99,9 @@ This is the _another_ emphasis.
 """,
         set_args=[
             "plugins.md049.style=consistent",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
+        use_strict_config=True,
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:5:13: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
 """,
@@ -134,7 +135,7 @@ This is the *another* emphasis.
 """,
         set_args=[
             "plugins.md049.style=consistent",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:5:13: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)
@@ -163,7 +164,7 @@ This is _one_ emphasis.
 """,
         set_args=[
             "plugins.md049.style=asterisk",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:3:9: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
@@ -192,7 +193,7 @@ This is *one* emphasis.
 """,
         set_args=[
             "plugins.md049.style=underscore",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:3:9: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)

--- a/test/rules/test_md049.py
+++ b/test/rules/test_md049.py
@@ -1,0 +1,242 @@
+"""
+Module to provide tests related to the MD048 rule.
+"""
+
+import os
+from test.rules.utils import (
+    execute_configuration_test,
+    execute_query_configuration_test,
+    execute_scan_test,
+    id_test_plug_rule_fn,
+    pluginConfigErrorTest,
+    pluginQueryConfigTest,
+    pluginRuleTest,
+)
+
+import pytest
+
+source_path = os.path.join("test", "resources", "rules", "md049") + os.sep
+
+configTests = [
+    pluginConfigErrorTest(
+        "invalid_style_type",
+        use_strict_config=True,
+        set_args=["plugins.md049.style=$#1"],
+        expected_error="""BadPluginError encountered while configuring plugins:
+The value for property 'plugins.md049.style' must be of type 'str'.""",
+    ),
+    pluginConfigErrorTest(
+        "invalid_style",
+        use_strict_config=True,
+        set_args=["plugins.md049.style=not-matching"],
+        expected_error="""BadPluginError encountered while configuring plugins:
+The value for property 'plugins.md049.style' is not valid: Allowable values: ['consistent', 'asterisk', 'underscore']""",
+    ),
+]
+
+
+scanTests = [
+    pluginRuleTest(
+        "good_default_with_consistent_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+
+This is the *same* emphasis.
+""",
+    ),
+    pluginRuleTest(
+        "bad_default_with_different_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+
+This is the _another_ emphasis.
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_default_with_consistent_underscore_emphasis",
+        source_file_contents="""This is _one_ emphasis.
+
+This is the _same_ emphasis.
+""",
+    ),
+    pluginRuleTest(
+        "bad_default_with_different_underscore_emphasis",
+        source_file_contents="""This is _one_ emphasis.
+
+This is the *another* emphasis.
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_consistent_with_consistent_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+
+This is the *same* emphasis.
+""",
+        set_args=["plugins.md049.style=consistent"],
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+
+This is the _another_ emphasis.
+""",
+        set_args=["plugins.md049.style=consistent"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_asterisk_emphasis_and_strikethrough",
+        source_file_contents="""This is ~strikethrough~ emphasis. (should not affect consistent)
+
+This is *one* emphasis.
+
+This is the _another_ emphasis.
+""",
+        set_args=[
+            "plugins.md049.style=consistent",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:13: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_consistent_with_consistent_underscore_emphasis",
+        source_file_contents="""This is _one_ emphasis.
+
+This is the _same_ emphasis.
+""",
+        set_args=["plugins.md049.style=consistent"],
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_underscore_emphasis",
+        source_file_contents="""This is _one_ emphasis.
+
+This is the *another* emphasis.
+""",
+        set_args=["plugins.md049.style=consistent"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_underscore_emphasis_and_strikethrough",
+        source_file_contents="""This is ~strikethrough~ emphasis. (should not affect consistent)
+
+This is _one_ emphasis.
+
+This is the *another* emphasis.
+""",
+        set_args=[
+            "plugins.md049.style=consistent",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:13: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_asterisk_with_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+""",
+        set_args=["plugins.md049.style=asterisk"],
+    ),
+    pluginRuleTest(
+        "bad_asterisk_with_underscore_emphasis",
+        source_file_contents="""This is _one_ emphasis.
+""",
+        set_args=["plugins.md049.style=asterisk"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:9: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_asterisk_with_strikethrough_emphasis",
+        source_file_contents="""This is ~strikethrough~.
+
+This is _one_ emphasis.
+""",
+        set_args=[
+            "plugins.md049.style=asterisk",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:9: MD049: Emphasis style [Expected: asterisk; Actual: underscore] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_underscore_with_underscore_emphasis",
+        source_file_contents="""This is _one_ emphasis.
+""",
+        set_args=["plugins.md049.style=underscore"],
+    ),
+    pluginRuleTest(
+        "bad_underscore_with_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+""",
+        set_args=["plugins.md049.style=underscore"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:9: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_underscore_with_strikethrough_emphasis",
+        source_file_contents="""This is ~strikethrough~.
+
+This is *one* emphasis.
+""",
+        set_args=[
+            "plugins.md049.style=underscore",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:9: MD049: Emphasis style [Expected: underscore; Actual: asterisk] (emphasis-style)
+""",
+    ),
+]
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize("test", scanTests, ids=id_test_plug_rule_fn)
+def test_md049_scan(test: pluginRuleTest) -> None:
+    """
+    Execute a parameterized scan test for plugin md001.
+    """
+    execute_scan_test(test, "md049")
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize("test", configTests, ids=id_test_plug_rule_fn)
+def test_md049_config(test: pluginConfigErrorTest) -> None:
+    """
+    Execute a parameterized fix test for plugin md001.
+    """
+    execute_configuration_test(test, f"{source_path}bad_fenced_backticks_and_tildes.md")
+
+
+@pytest.mark.rules
+def test_md049_query_config() -> None:
+    config_test = pluginQueryConfigTest(
+        "md049",
+        """
+  ITEM               DESCRIPTION
+
+  Id                 md049
+  Name(s)            emphasis-style
+  Short Description  Emphasis style
+  Description Url    https://pymarkdown.readthedocs.io/en/latest/plugins/rule_
+                     md049.md
+
+
+  CONFIGURATION ITEM  TYPE    VALUE
+
+  style               string  "consistent"
+
+""",
+    )
+    execute_query_configuration_test(config_test)

--- a/test/rules/test_md050.py
+++ b/test/rules/test_md050.py
@@ -99,7 +99,7 @@ This is the __another__ strong emphasis.
 """,
         set_args=[
             "plugins.md050.style=consistent",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:5:13: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
@@ -134,7 +134,7 @@ This is the **another** strong emphasis.
 """,
         set_args=[
             "plugins.md050.style=consistent",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:5:13: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)
@@ -163,7 +163,7 @@ This is __one__ strong emphasis.
 """,
         set_args=[
             "plugins.md050.style=asterisk",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:3:9: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
@@ -192,7 +192,7 @@ This is **one** strong emphasis.
 """,
         set_args=[
             "plugins.md050.style=underscore",
-            "extensions.markdown-strikethrough.enabled=#!True",
+            "extensions.markdown-strikethrough.enabled=$!True",
         ],
         scan_expected_return_code=1,
         scan_expected_output="""{temp_source_path}:3:9: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)

--- a/test/rules/test_md050.py
+++ b/test/rules/test_md050.py
@@ -1,0 +1,242 @@
+"""
+Module to provide tests related to the MD048 rule.
+"""
+
+import os
+from test.rules.utils import (
+    execute_configuration_test,
+    execute_query_configuration_test,
+    execute_scan_test,
+    id_test_plug_rule_fn,
+    pluginConfigErrorTest,
+    pluginQueryConfigTest,
+    pluginRuleTest,
+)
+
+import pytest
+
+source_path = os.path.join("test", "resources", "rules", "md050") + os.sep
+
+configTests = [
+    pluginConfigErrorTest(
+        "invalid_style_type",
+        use_strict_config=True,
+        set_args=["plugins.md050.style=$#1"],
+        expected_error="""BadPluginError encountered while configuring plugins:
+The value for property 'plugins.md050.style' must be of type 'str'.""",
+    ),
+    pluginConfigErrorTest(
+        "invalid_style",
+        use_strict_config=True,
+        set_args=["plugins.md050.style=not-matching"],
+        expected_error="""BadPluginError encountered while configuring plugins:
+The value for property 'plugins.md050.style' is not valid: Allowable values: ['consistent', 'asterisk', 'underscore']""",
+    ),
+]
+
+
+scanTests = [
+    pluginRuleTest(
+        "good_default_with_consistent_asterisk_strong_emphasis",
+        source_file_contents="""This is **one** strong emphasis.
+
+This is the **same** strong emphasis.
+""",
+    ),
+    pluginRuleTest(
+        "bad_default_with_different_asterisk_strong_emphasis",
+        source_file_contents="""This is **one** strong emphasis.
+
+This is the __another__ strong emphasis.
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_default_with_consistent_underscore_strong_emphasis",
+        source_file_contents="""This is __one__ strong emphasis.
+
+This is the __same__ strong emphasis.
+""",
+    ),
+    pluginRuleTest(
+        "bad_default_with_different_underscore_strong_emphasis",
+        source_file_contents="""This is __one__ strong emphasis.
+
+This is the **another** strong emphasis.
+""",
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_consistent_with_consistent_asterisk_emphasis",
+        source_file_contents="""This is *one* emphasis.
+
+This is the *same* emphasis.
+""",
+        set_args=["plugins.md050.style=consistent"],
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_asterisk_strong_emphasis",
+        source_file_contents="""This is **one** strong emphasis.
+
+This is the __another__ strong emphasis.
+""",
+        set_args=["plugins.md050.style=consistent"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_asterisk_strong_emphasis_and_strikethrough",
+        source_file_contents="""This is ~~strikethrough~~ emphasis. (should not affect consistent)
+
+This is **one** strong emphasis.
+
+This is the __another__ strong emphasis.
+""",
+        set_args=[
+            "plugins.md050.style=consistent",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:13: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_consistent_with_consistent_underscore_strong_emphasis",
+        source_file_contents="""This is __one__ strong emphasis.
+
+This is the __same__ strong emphasis.
+""",
+        set_args=["plugins.md050.style=consistent"],
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_underscore_strong_emphasis",
+        source_file_contents="""This is __one__ strong emphasis.
+
+This is the **another** strong emphasis.
+""",
+        set_args=["plugins.md050.style=consistent"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:13: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_consistent_with_different_underscore_strong_emphasis_and_strikethrough",
+        source_file_contents="""This is ~strikethrough~ emphasis. (should not affect consistent)
+
+This is __one__ strong emphasis.
+
+This is the **another** strong emphasis.
+""",
+        set_args=[
+            "plugins.md050.style=consistent",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:5:13: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_asterisk_with_asterisk_strong_emphasis",
+        source_file_contents="""This is **one** strong emphasis.
+""",
+        set_args=["plugins.md050.style=asterisk"],
+    ),
+    pluginRuleTest(
+        "bad_asterisk_with_underscore_strong_emphasis",
+        source_file_contents="""This is __one__ strong emphasis.
+""",
+        set_args=["plugins.md050.style=asterisk"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:9: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_asterisk_with_underscore_strong_emphasis_strikethrough",
+        source_file_contents="""This is ~~strikethrough~~.
+
+This is __one__ strong emphasis.
+""",
+        set_args=[
+            "plugins.md050.style=asterisk",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:9: MD050: Strong style [Expected: asterisk; Actual: underscore] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "good_underscore_with_underscore_strong_emphasis",
+        source_file_contents="""This is __one__ strong emphasis.
+""",
+        set_args=["plugins.md050.style=underscore"],
+    ),
+    pluginRuleTest(
+        "bad_underscore_with_asterisk_strong_emphasis",
+        source_file_contents="""This is **one** strong emphasis.
+""",
+        set_args=["plugins.md050.style=underscore"],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:1:9: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)
+""",
+    ),
+    pluginRuleTest(
+        "bad_underscore_with_asterisk_strong_emphasis_strikethrough",
+        source_file_contents="""This is ~~strikethrough~~.
+
+This is **one** strong emphasis.
+""",
+        set_args=[
+            "plugins.md050.style=underscore",
+            "extensions.markdown-strikethrough.enabled=#!True",
+        ],
+        scan_expected_return_code=1,
+        scan_expected_output="""{temp_source_path}:3:9: MD050: Strong style [Expected: underscore; Actual: asterisk] (strong-style)
+""",
+    ),
+]
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize("test", scanTests, ids=id_test_plug_rule_fn)
+def test_md050_scan(test: pluginRuleTest) -> None:
+    """
+    Execute a parameterized scan test for plugin md001.
+    """
+    execute_scan_test(test, "md050")
+
+
+@pytest.mark.rules
+@pytest.mark.parametrize("test", configTests, ids=id_test_plug_rule_fn)
+def test_md050_config(test: pluginConfigErrorTest) -> None:
+    """
+    Execute a parameterized fix test for plugin md001.
+    """
+    execute_configuration_test(test, f"{source_path}bad_fenced_backticks_and_tildes.md")
+
+
+@pytest.mark.rules
+def test_md050_query_config() -> None:
+    config_test = pluginQueryConfigTest(
+        "md050",
+        """
+  ITEM               DESCRIPTION
+
+  Id                 md050
+  Name(s)            strong-style
+  Short Description  Strong style
+  Description Url    https://pymarkdown.readthedocs.io/en/latest/plugins/rule_
+                     md050.md
+
+
+  CONFIGURATION ITEM  TYPE    VALUE
+
+  style               string  "consistent"
+
+""",
+    )
+    execute_query_configuration_test(config_test)

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -1700,6 +1700,34 @@ def test_markdown_with_plugins_list_and_filter_by_id_ends_with_nine(
     execute_results.assert_results(expected_results=expected_results)
 
 
+def test_markdown_with_plugins_list_and_filter_by_wrong_case_id(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure that `plugins list` lists all plugins with the specified id filter.
+    """
+
+    # Arrange
+    supplied_arguments = ["plugins", "list", "Md019"]
+
+    expected_results = ExpectedResults(
+        return_code=0,
+        expected_output="""
+  ID     NAMES                  ENABLED    ENABLED    VERSION  FIX
+                                (DEFAULT)  (CURRENT)
+
+  md019  no-multiple-space-atx  True       True       0.5.1    Yes
+
+""",
+    )
+
+    # Act
+    execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+    # Assert
+    execute_results.assert_results(expected_results=expected_results)
+
+
 def test_markdown_with_plugins_list_and_filter_by_id_ends_with_non_sequence(
     scanner_default: MarkdownScanner,
 ) -> None:
@@ -1830,6 +1858,44 @@ def test_markdown_with_plugins_info_and_not_found_filter(
     expected_results = ExpectedResults(
         return_code=1,
         expected_error="Unable to find a plugin with an id or name of 'md00001'.",
+    )
+
+    # Act
+    execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+    # Assert
+    execute_results.assert_results(
+        expected_results=expected_results,
+    )
+
+
+def test_markdown_with_plugins_info_and_wrong_case_filter(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure that `plugins list` errors when a valid id or name is not found.
+    """
+
+    # Arrange
+    supplied_arguments = ["plugins", "info", "Md001"]
+
+    expected_results = ExpectedResults(
+        return_code=0,
+        expected_output="""
+  ITEM               DESCRIPTION
+
+  Id                 md001
+  Name(s)            heading-increment,header-increment
+  Short Description  Heading levels should only increment by one level at a ti
+                     me.
+  Description Url    https://pymarkdown.readthedocs.io/en/latest/plugins/rule_
+                     md001.md
+
+
+  CONFIGURATION ITEM  TYPE    VALUE
+
+  front_matter_title  string  "title"
+""",
     )
 
     # Act

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -1710,34 +1710,6 @@ def test_markdown_with_plugins_list_and_filter_by_id_ends_with_nine(
     execute_results.assert_results(expected_results=expected_results)
 
 
-def test_markdown_with_plugins_list_and_filter_by_wrong_case_id(
-    scanner_default: MarkdownScanner,
-) -> None:
-    """
-    Test to make sure that `plugins list` lists all plugins with the specified id filter.
-    """
-
-    # Arrange
-    supplied_arguments = ["plugins", "list", "Md019"]
-
-    expected_results = ExpectedResults(
-        return_code=0,
-        expected_output="""
-  ID     NAMES                  ENABLED    ENABLED    VERSION  FIX
-                                (DEFAULT)  (CURRENT)
-
-  md019  no-multiple-space-atx  True       True       0.5.1    Yes
-
-""",
-    )
-
-    # Act
-    execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
-
-    # Assert
-    execute_results.assert_results(expected_results=expected_results)
-
-
 def test_markdown_with_plugins_list_and_filter_by_id_ends_with_non_sequence(
     scanner_default: MarkdownScanner,
 ) -> None:
@@ -2887,3 +2859,30 @@ def test_markdown_plugins_failures_no_plugins_active_fix(
             expected_error,
             expected_return_code,
         )
+
+def test_markdown_with_plugins_list_and_filter_by_wrong_case_id(
+    scanner_default: MarkdownScanner,
+) -> None:
+    """
+    Test to make sure that `plugins list` lists all plugins with the specified id filter.
+    """
+
+    # Arrange
+    supplied_arguments = ["plugins", "list", "Md019"]
+
+    expected_results = ExpectedResults(
+        return_code=0,
+        expected_output="""
+  ID     NAMES                  ENABLED    ENABLED    VERSION  FIX
+                                (DEFAULT)  (CURRENT)
+
+  md019  no-multiple-space-atx  True       True       0.5.1    Yes
+
+""",
+    )
+
+    # Act
+    execute_results = scanner_default.invoke_main(arguments=supplied_arguments)
+
+    # Assert
+    execute_results.assert_results(expected_results=expected_results)

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -1310,6 +1310,8 @@ def test_markdown_with_plugins_list_only(scanner_default: MarkdownScanner) -> No
   md046   code-block-style                True       True       0.7.0    Yes
   md047   single-trailing-newline         True       True       0.5.2    Yes
   md048   code-fence-style                True       True       0.6.0    Yes
+  md049   emphasis-style                  True       True       0.5.0    No
+  md050   strong-style                    True       True       0.5.0    No
   pml100  disallowed-html                 False      False      0.6.0    No
   pml101  list-anchored-indent            False      False      0.6.0    No
   pml102  disallow-lazy-list-indentation  False      False      0.5.0    No
@@ -1392,6 +1394,8 @@ def test_markdown_with_plugins_list_only_all(scanner_default: MarkdownScanner) -
   md046   code-block-style                True       True       0.7.0    Yes
   md047   single-trailing-newline         True       True       0.5.2    Yes
   md048   code-fence-style                True       True       0.6.0    Yes
+  md049   emphasis-style                  True       True       0.5.0    No
+  md050   strong-style                    True       True       0.5.0    No
   md999   debug-only                      False      False      0.0.0    No
   pml100  disallowed-html                 False      False      0.6.0    No
   pml101  list-anchored-indent            False      False      0.6.0    No
@@ -1476,6 +1480,8 @@ def test_markdown_with_plugins_list_after_command_line_disable_all_rules(
   md046   code-block-style                True       False      0.7.0    Yes
   md047   single-trailing-newline         True       False      0.5.2    Yes
   md048   code-fence-style                True       False      0.6.0    Yes
+  md049   emphasis-style                  True       False      0.5.0    No
+  md050   strong-style                    True       False      0.5.0    No
   pml100  disallowed-html                 False      False      0.6.0    No
   pml101  list-anchored-indent            False      False      0.6.0    No
   pml102  disallow-lazy-list-indentation  False      False      0.5.0    No
@@ -1564,9 +1570,11 @@ def test_markdown_with_plugins_list_after_configuration_disable_all_rules(
   md046   code-block-style                True       False      0.7.0    Yes
   md047   single-trailing-newline         True       False      0.5.2    Yes
   md048   code-fence-style                True       False      0.6.0    Yes
+  md049   emphasis-style                  True       False      0.5.0    No
+  md050   strong-style                    True       False      0.5.0    No
   pml100  disallowed-html                 False      False      0.6.0    No
   pml101  list-anchored-indent            False      False      0.6.0    No
-  pml102  disallow-lazy-list-indentation  False      False      0.5.0    No  
+  pml102  disallow-lazy-list-indentation  False      False      0.5.0    No
 """,
         )
 
@@ -1654,9 +1662,11 @@ def test_markdown_with_plugins_list_after_command_line_disable_all_rules_and_ena
   md046   code-block-style                True       False      0.7.0    Yes
   md047   single-trailing-newline         True       False      0.5.2    Yes
   md048   code-fence-style                True       False      0.6.0    Yes
+  md049   emphasis-style                  True       False      0.5.0    No
+  md050   strong-style                    True       False      0.5.0    No
   pml100  disallowed-html                 False      False      0.6.0    No
   pml101  list-anchored-indent            False      False      0.6.0    No
-  pml102  disallow-lazy-list-indentation  False      False      0.5.0    No  
+  pml102  disallow-lazy-list-indentation  False      False      0.5.0    No
 """,
     )
 
@@ -1689,7 +1699,7 @@ def test_markdown_with_plugins_list_and_filter_by_id_ends_with_nine(
   md019  no-multiple-space-atx  True       True       0.5.1    Yes
   md029  ol-prefix              True       True       0.6.0    Yes
   md039  no-space-in-links      True       True       0.5.2    Yes
-
+  md049  emphasis-style         True       True       0.5.0    No
 """,
     )
 

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -2860,7 +2860,7 @@ def test_markdown_plugins_failures_no_plugins_active_fix(
             expected_return_code,
         )
 
-def test_markdown_with_plugins_list_and_filter_by_wrong_case_id(
+def test_markdown_with_plugins_list_and_filter_by_wrong_case_plugin_id(
     scanner_default: MarkdownScanner,
 ) -> None:
     """

--- a/test/rules/test_plugin_manager.py
+++ b/test/rules/test_plugin_manager.py
@@ -2860,6 +2860,7 @@ def test_markdown_plugins_failures_no_plugins_active_fix(
             expected_return_code,
         )
 
+
 def test_markdown_with_plugins_list_and_filter_by_wrong_case_plugin_id(
     scanner_default: MarkdownScanner,
 ) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Introduce new emphasis styling rules (MD049, MD050) and update plugin/extension command filters to be case-insensitive, with corresponding tests and documentation updates.

New Features:
- Add new MD049 and MD050 rules to enforce consistent emphasis and strong emphasis styles in Markdown documents.
- Document the new MD049 and MD050 rules in the rules and plugin documentation.

Bug Fixes:
- Make `extensions` and `plugins` list and info filters case-insensitive so IDs and names match regardless of input casing.

Documentation:
- Update changelog to record addition of MD049/MD050 rules and case-insensitivity fix for extensions and plugins commands.

Tests:
- Add comprehensive rule and configuration tests for MD049 and MD050, including query configuration coverage.
- Extend plugin and extension manager tests to cover case-insensitive filtering behavior for list and info commands.
- Adjust existing MD037 tests and plugin listing expectations to account for the new rules.