### PR TITLE
Fix typo and duplicate theme in mkdocs config

### DIFF
--- a/newdocs/mkdocs.yml
+++ b/newdocs/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: PyMarkdown Linter (PyMarkdownLnt)
 # site_url: http://127.0.0.1:8000/
 site_description: Documentation for the PyMarkdown Linter project.
 site_author: Jack De Winter
-theme: readthedocs
 # repo_url: https://github.com/jackdewinter/pymarkdown
 docs_dir: src
 site_dir: site
@@ -47,7 +46,7 @@ nav:
   - "Extensions & Rule Plugins":
     - extensions.md
     - rules.md
-  - "Devloper Guide":
+  - "Developer Guide":
     - "API Listing": api/pymarkdownapi.md
     - 'api.md'
     - 'development.md'


### PR DESCRIPTION
This PR fixes the mkdocs config:

- removed duplicate `theme`
- fixed typo that is displayed in the docs TOC

## Summary by Sourcery

Clean up the MkDocs configuration by removing the duplicate theme entry and correcting the documentation navigation label.

Bug Fixes:
- Correct the Developer Guide label in the documentation table of contents.

Enhancements:
- Remove the duplicate MkDocs theme configuration.

Documentation:
- Clean up the MkDocs configuration used to generate project documentation.